### PR TITLE
[APM][OTel] Ensure Errors views works with OTel Data

### DIFF
--- a/packages/kbn-apm-types/src/es_fields/apm.ts
+++ b/packages/kbn-apm-types/src/es_fields/apm.ts
@@ -131,6 +131,7 @@ export const ERROR_EXC_MESSAGE = 'error.exception.message'; // only to be used i
 export const ERROR_EXC_HANDLED = 'error.exception.handled'; // only to be used in es queries, since error.exception is now an array
 export const ERROR_EXC_TYPE = 'error.exception.type';
 export const ERROR_PAGE_URL = 'error.page.url';
+export const ERROR_STACK_TRACE = 'error.stack_trace';
 export const ERROR_TYPE = 'error.type';
 
 // METRICS

--- a/x-pack/plugins/observability_solution/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
+++ b/x-pack/plugins/observability_solution/apm/common/es_fields/__snapshots__/es_fields.test.ts.snap
@@ -114,6 +114,8 @@ exports[`Error ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Error ERROR_PAGE_URL 1`] = `undefined`;
 
+exports[`Error ERROR_STACK_TRACE 1`] = `undefined`;
+
 exports[`Error ERROR_TYPE 1`] = `undefined`;
 
 exports[`Error EVENT_NAME 1`] = `undefined`;
@@ -509,6 +511,8 @@ exports[`Span ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Span ERROR_PAGE_URL 1`] = `undefined`;
 
+exports[`Span ERROR_STACK_TRACE 1`] = `undefined`;
+
 exports[`Span ERROR_TYPE 1`] = `undefined`;
 
 exports[`Span EVENT_NAME 1`] = `undefined`;
@@ -899,6 +903,8 @@ exports[`Transaction ERROR_LOG_LEVEL 1`] = `undefined`;
 exports[`Transaction ERROR_LOG_MESSAGE 1`] = `undefined`;
 
 exports[`Transaction ERROR_PAGE_URL 1`] = `undefined`;
+
+exports[`Transaction ERROR_STACK_TRACE 1`] = `undefined`;
 
 exports[`Transaction ERROR_TYPE 1`] = `undefined`;
 

--- a/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_group_main_statistics.ts
@@ -166,10 +166,10 @@ export async function getErrorGroupMainStatistics({
         name: getErrorName({ error: normalizedFields?.error } as APMError),
         lastSeen: new Date(normalizedFields?.['@timestamp'] as string).getTime(),
         occurrences: bucket.doc_count,
-        culprit: normalizedFields?.error?.culprit,
-        handled: normalizedFields?.error?.exception[0]?.handled,
-        type: normalizedFields?.error?.exception[0]?.type,
-        traceId: normalizedFields?.trace?.id,
+        culprit: normalizedFields?.error.culprit,
+        handled: normalizedFields?.error.exception[0].handled,
+        type: normalizedFields?.error.exception[0].type,
+        traceId: normalizedFields?.trace.id,
       };
     }) ?? [];
 

--- a/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_group_sample_ids.ts
+++ b/x-pack/plugins/observability_solution/apm/server/routes/errors/get_error_groups/get_error_group_sample_ids.ts
@@ -6,6 +6,7 @@
  */
 
 import { rangeQuery, kqlQuery } from '@kbn/observability-plugin/server';
+import { normalizeValue } from '../../../utils/es_fields_mappings/es_fields_mappings_helpers';
 import { asMutableArray } from '../../../../common/utils/as_mutable_array';
 import {
   ERROR_GROUP_ID,
@@ -66,7 +67,7 @@ export async function getErrorGroupSampleIds({
           should: [{ term: { [TRANSACTION_SAMPLED]: true } }], // prefer error samples with related transactions
         },
       },
-      _source: [ERROR_ID, 'transaction'],
+      fields: [ERROR_ID],
       sort: asMutableArray([
         { _score: { order: 'desc' } }, // sort by _score first to ensure that errors with transaction.sampled:true ends up on top
         { '@timestamp': { order: 'desc' } }, // sort by timestamp to get the most recent error
@@ -74,8 +75,10 @@ export async function getErrorGroupSampleIds({
     },
   });
   const errorSampleIds = resp.hits.hits.map((item) => {
-    const source = item._source;
-    return source?.error?.id;
+    const fields = item.fields;
+    const errorId = normalizeValue<string>(fields?.['error.id']);
+
+    return errorId;
   });
 
   return {

--- a/x-pack/plugins/observability_solution/apm/server/utils/es_fields_mappings/error.ts
+++ b/x-pack/plugins/observability_solution/apm/server/utils/es_fields_mappings/error.ts
@@ -73,7 +73,6 @@ export const errorGroupMainStatisticsMapping = (fields: Fields) => {
       id: normalizeValue<string>(fields[TRACE_ID]),
     },
     error: {
-      id: normalizeValue<string>(fields[ERROR_ID]),
       log: {
         message: normalizeValue<string>(fields[ERROR_LOG_MESSAGE]),
       },
@@ -85,7 +84,6 @@ export const errorGroupMainStatisticsMapping = (fields: Fields) => {
         },
       ],
       culprit: normalizeValue<string>(fields[ERROR_CULPRIT]),
-      grouping_key: normalizeValue<string>(fields[ERROR_GROUP_ID]),
     },
     '@timestamp': normalizeValue<string>(fields[AT_TIMESTAMP]),
   };

--- a/x-pack/plugins/observability_solution/apm/server/utils/es_fields_mappings/error.ts
+++ b/x-pack/plugins/observability_solution/apm/server/utils/es_fields_mappings/error.ts
@@ -17,6 +17,7 @@ import {
   ERROR_EXC_HANDLED,
   ERROR_EXC_TYPE,
   ERROR_CULPRIT,
+  ERROR_STACK_TRACE,
   AT_TIMESTAMP,
   APMError,
   OBSERVER_TYPE,
@@ -119,6 +120,7 @@ export const errorSampleDetailsMapping = (fields: Fields): APMError | undefined 
         },
       ],
       grouping_key: normalizeValue<string>(fields[ERROR_GROUP_ID]),
+      stack_trace: normalizeValue<string>(fields[ERROR_STACK_TRACE]),
     },
     processor: {
       name: normalizeValue<'error'>(fields[PROCESSOR_NAME]),


### PR DESCRIPTION
## Summary
Closes https://github.com/elastic/kibana/issues/192336

https://github.com/user-attachments/assets/7580ce62-74c5-4357-9add-a57b9bba63df

## How to test
1. Make sure to use https://github.com/elastic/otel-apm-e2e-poc and running with opentelemetry-demo data https://github.com/elastic/otel-apm-e2e-poc
2. Change the indices in Settings to only use `*otel*` indices.
3. Inside APM, search for `error.exception.handled:true` to see failing services
4. Deep dive into Errors and explore everything is working fine

