### PR TITLE
K8s OTel/ECS content rendering

### DIFF
--- a/x-pack/solutions/observability/plugins/infra/common/constants.ts
+++ b/x-pack/solutions/observability/plugins/infra/common/constants.ts
@@ -51,9 +51,20 @@ export const KUBERNETES_POD_UID_FIELD = 'kubernetes.pod.uid';
 export const EVENT_MODULE = 'event.module';
 export const METRICSET_MODULE = 'metricset.module';
 export const METRICSET_NAME = 'metricset.name';
+export const DATASTREAM_DATASET = 'data_stream.dataset';
+
+// metricbeat
+export const AGENT_TYPE = 'agent.type';
+export const METRICBEAT = 'metricbeat';
+
+// OTel hostmetricsreceiver
+export const OTEL_RECEIVER_DATASET_VALUE = 'hostmetricsreceiver.otel';
+// OTel dataset
+export const OTEL_DATASET_VALUE = '*.otel';
 
 // integrations
 export const SYSTEM_INTEGRATION = 'system';
+export const KUBERNETES_INTEGRATION = 'kubernetes';
 
 // logs
 export const MESSAGE_FIELD = 'message';

--- a/x-pack/solutions/observability/plugins/infra/common/metrics_sources/get_has_data.ts
+++ b/x-pack/solutions/observability/plugins/infra/common/metrics_sources/get_has_data.ts
@@ -5,7 +5,13 @@
  * 2.0.
  */
 
+import { isoToEpochRt } from '@kbn/io-ts-utils';
 import * as rt from 'io-ts';
+
+export const supportedDataSourcesRT = rt.keyof({
+  host: null,
+  kubernetes: null,
+});
 
 export const getHasDataQueryParamsRT = rt.partial({
   // Integrations `event.module` value
@@ -16,5 +22,29 @@ export const getHasDataResponseRT = rt.partial({
   hasData: rt.boolean,
 });
 
+export const getTimeRangeMetadataQueryParamsRT = rt.intersection([
+  rt.partial({
+    kuery: rt.string,
+  }),
+  rt.type({
+    dataSource: supportedDataSourcesRT,
+    from: isoToEpochRt,
+    to: isoToEpochRt,
+  }),
+]);
+
+export const getTimeRangeMetadataResponseRT = rt.type({
+  schemas: rt.array(
+    rt.keyof({
+      ecs: null,
+      semconv: null,
+    })
+  ),
+});
+
+export type SupportedDataSources = rt.TypeOf<typeof supportedDataSourcesRT>;
 export type GetHasDataQueryParams = rt.TypeOf<typeof getHasDataQueryParamsRT>;
 export type GetHasDataResponse = rt.TypeOf<typeof getHasDataResponseRT>;
+
+export type GetTimeRangeMetadataQueryParams = rt.TypeOf<typeof getTimeRangeMetadataQueryParamsRT>;
+export type GetTimeRangeMetadataResponse = rt.TypeOf<typeof getTimeRangeMetadataResponseRT>;

--- a/x-pack/solutions/observability/plugins/infra/public/hooks/use_timerange_metadata.ts
+++ b/x-pack/solutions/observability/plugins/infra/public/hooks/use_timerange_metadata.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { decodeOrThrow } from '@kbn/io-ts-utils';
+import createContainer from 'constate';
+import {
+  getTimeRangeMetadataResponseRT,
+  type SupportedDataSources,
+} from '../../common/metrics_sources/get_has_data';
+import { useFetcher } from './use_fetcher';
+
+const useTimeRangeMetadata = ({
+  dataSource,
+  kuery,
+  start,
+  end,
+}: {
+  kuery?: string;
+  dataSource: SupportedDataSources;
+  start: string;
+  end: string;
+}) => {
+  const fetcherResult = useFetcher(
+    async (callApi) => {
+      const response = await callApi('/api/metrics/source/time_range_metadata', {
+        method: 'GET',
+        query: {
+          from: start,
+          to: end,
+          kuery,
+          dataSource,
+        },
+      });
+
+      return decodeOrThrow(getTimeRangeMetadataResponseRT)(response);
+    },
+    [start, end, kuery, dataSource]
+  );
+
+  return fetcherResult;
+};
+
+export const [TimeRangeMetadataProvider, useTimeRangeMetadataContext] =
+  createContainer(useTimeRangeMetadata);

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/dashboard/render_dashboard.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/dashboard/render_dashboard.tsx
@@ -14,7 +14,6 @@ import type { SerializableRecord } from '@kbn/utility-types';
 import type { DashboardState } from '@kbn/dashboard-plugin/common';
 import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
 import { useDatePickerContext } from '../../hooks/use_date_picker';
-import { useTimeRangeMetadataContext } from '../../../../../hooks/use_timerange_metadata';
 
 export const RenderDashboard = ({ dashboardId }: { dashboardId: string }) => {
   const {
@@ -22,7 +21,6 @@ export const RenderDashboard = ({ dashboardId }: { dashboardId: string }) => {
   } = useKibanaContextForPlugin();
 
   const { dateRange } = useDatePickerContext();
-  const { data } = useTimeRangeMetadataContext();
   const { from, to } = dateRange;
   const getCreationOptions = useCallback((): Promise<DashboardCreationOptions> => {
     const getInitialInput = (): Partial<DashboardState> => ({
@@ -42,11 +40,6 @@ export const RenderDashboard = ({ dashboardId }: { dashboardId: string }) => {
     },
     [dashboardId]
   );
-
-  // TODO loading state and error handling
-  // move to a separate component
-  // console.log('schemas', data?.schemas);
-  // schema logic switcher otel, metricbeat, otel + metricbeat, none
 
   const locator = useMemo(() => {
     const baseLocator = share.url.locators.get(KUBERNETES_DASHBOARD_LOCATOR_ID);

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/dashboard/render_dashboard.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/dashboard/render_dashboard.tsx
@@ -14,6 +14,7 @@ import type { SerializableRecord } from '@kbn/utility-types';
 import type { DashboardState } from '@kbn/dashboard-plugin/common';
 import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
 import { useDatePickerContext } from '../../hooks/use_date_picker';
+import { useTimeRangeMetadataContext } from '../../../../../hooks/use_timerange_metadata';
 
 export const RenderDashboard = ({ dashboardId }: { dashboardId: string }) => {
   const {
@@ -21,6 +22,7 @@ export const RenderDashboard = ({ dashboardId }: { dashboardId: string }) => {
   } = useKibanaContextForPlugin();
 
   const { dateRange } = useDatePickerContext();
+  const { data } = useTimeRangeMetadataContext();
   const { from, to } = dateRange;
   const getCreationOptions = useCallback((): Promise<DashboardCreationOptions> => {
     const getInitialInput = (): Partial<DashboardState> => ({
@@ -40,6 +42,11 @@ export const RenderDashboard = ({ dashboardId }: { dashboardId: string }) => {
     },
     [dashboardId]
   );
+
+  // TODO loading state and error handling
+  // move to a separate component
+  // console.log('schemas', data?.schemas);
+  // schema logic switcher otel, metricbeat, otel + metricbeat, none
 
   const locator = useMemo(() => {
     const baseLocator = share.url.locators.get(KUBERNETES_DASHBOARD_LOCATOR_ID);

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/page_content/page_content.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/page_content/page_content.tsx
@@ -1,0 +1,82 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React, { useState, useMemo } from 'react';
+import { i18n } from '@kbn/i18n';
+import { EuiFormRow, EuiLoadingSpinner, EuiSwitch } from '@elastic/eui';
+import { useTimeRangeMetadataContext } from '../../../../../hooks/use_timerange_metadata';
+import { RenderDashboard } from '../dashboard/render_dashboard';
+
+const OverviewDashboardsPerSchema = {
+  semconv: 'kubernetes_otel-cluster-overview',
+  ecs: 'kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c',
+} as const;
+
+export const PageContent = ({
+  dashboardId,
+  hasMultipleDashboards,
+}: {
+  dashboardId: string;
+  hasMultipleDashboards: boolean;
+}) => {
+  const { data, status } = useTimeRangeMetadataContext();
+  const [currentDashboardId, setCurrentDashboardId] = useState(
+    hasMultipleDashboards ? OverviewDashboardsPerSchema.semconv : dashboardId
+  );
+
+  const onChange = (e: { target: { checked: React.SetStateAction<boolean> } }) => {
+    setCurrentDashboardId(
+      e.target.checked
+        ? OverviewDashboardsPerSchema.semconv
+        : dashboardId ?? OverviewDashboardsPerSchema.ecs
+    );
+  };
+
+  const shouldRenderMultipleDashboardsToggle = useMemo(
+    () =>
+      Object.keys(OverviewDashboardsPerSchema).every((key) =>
+        data?.schemas.includes(key as keyof typeof OverviewDashboardsPerSchema)
+      ),
+    [data?.schemas]
+  );
+
+  if (status === 'loading') {
+    return <EuiLoadingSpinner size="xl" />;
+  }
+
+  if (data?.schemas === undefined) {
+    return null;
+  }
+
+  if (shouldRenderMultipleDashboardsToggle) {
+    return (
+      <>
+        <EuiFormRow
+          display="columnCompressed"
+          label={
+            <span id={currentDashboardId}>
+              {i18n.translate('xpack.infra.pageContent.span.otelfocusedDashboardLabel', {
+                defaultMessage: 'OTel-focused dashboard',
+              })}
+            </span>
+          }
+        >
+          <EuiSwitch
+            label={currentDashboardId === OverviewDashboardsPerSchema.semconv ? 'otel' : 'ecs'}
+            checked={currentDashboardId === OverviewDashboardsPerSchema.semconv}
+            onChange={onChange}
+            aria-describedby={currentDashboardId}
+            compressed
+          />
+        </EuiFormRow>
+        <RenderDashboard dashboardId={currentDashboardId} />
+      </>
+    );
+  }
+
+  return <RenderDashboard dashboardId={dashboardId} />;
+};

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/hooks/use_kubernetes_timerange_metadata.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/hooks/use_kubernetes_timerange_metadata.tsx
@@ -1,0 +1,33 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+import React from 'react';
+import { useTimeRange } from '../../../../hooks/use_time_range';
+import { TimeRangeMetadataProvider } from '../../../../hooks/use_timerange_metadata';
+import { useDatePickerContext } from './use_date_picker';
+
+export function KubernetesTimeRangeMetadataProvider({ children }: { children: React.ReactNode }) {
+  // TODO use dateRange
+  const { dateRange } = useDatePickerContext();
+  const from = new Date(Date.now() - 1000 * 60 * 10).toISOString();
+  const to = new Date().toISOString();
+
+  const parsedDateRange = useTimeRange({
+    rangeFrom: from,
+    rangeTo: to,
+  });
+
+  return (
+    <TimeRangeMetadataProvider
+      kuery=""
+      dataSource="kubernetes"
+      start={parsedDateRange.from}
+      end={parsedDateRange.to}
+    >
+      {children}
+    </TimeRangeMetadataProvider>
+  );
+}

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/index.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/index.tsx
@@ -16,6 +16,7 @@ import { useFetchDashboardById } from './hooks/use_fetch_dashboard_by_id';
 import { DatePicker } from './components/date_picker/date_picker';
 import { DatePickerProvider } from './hooks/use_date_picker';
 import { RenderDashboard } from './components/dashboard/render_dashboard';
+import { KubernetesTimeRangeMetadataProvider } from './hooks/use_kubernetes_timerange_metadata';
 
 export const Dashboard = () => {
   const {
@@ -75,7 +76,9 @@ export const Dashboard = () => {
           }}
           data-test-subj="infraKubernetesPage"
         >
-          <RenderDashboard dashboardId={dashboardId} />
+          <KubernetesTimeRangeMetadataProvider>
+            <RenderDashboard dashboardId={dashboardId} />
+          </KubernetesTimeRangeMetadataProvider>
         </PageTemplate>
       </EuiErrorBoundary>
     </DatePickerProvider>

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/index.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/index.tsx
@@ -15,8 +15,8 @@ import { useKibanaContextForPlugin } from '../../../hooks/use_kibana';
 import { useFetchDashboardById } from './hooks/use_fetch_dashboard_by_id';
 import { DatePicker } from './components/date_picker/date_picker';
 import { DatePickerProvider } from './hooks/use_date_picker';
-import { RenderDashboard } from './components/dashboard/render_dashboard';
 import { KubernetesTimeRangeMetadataProvider } from './hooks/use_kubernetes_timerange_metadata';
+import { PageContent } from './components/page_content/page_content';
 
 export const Dashboard = () => {
   const {
@@ -77,7 +77,7 @@ export const Dashboard = () => {
           data-test-subj="infraKubernetesPage"
         >
           <KubernetesTimeRangeMetadataProvider>
-            <RenderDashboard dashboardId={dashboardId} />
+            <PageContent dashboardId={dashboardId} hasMultipleDashboards={entity === 'overview'} />
           </KubernetesTimeRangeMetadataProvider>
         </PageTemplate>
       </EuiErrorBoundary>

--- a/x-pack/solutions/observability/plugins/infra/server/lib/helpers/get_infra_metrics_client.ts
+++ b/x-pack/solutions/observability/plugins/infra/server/lib/helpers/get_infra_metrics_client.ts
@@ -4,20 +4,29 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import type { SearchRequest as ESSearchRequest } from '@elastic/elasticsearch/lib/api/types';
+import type {
+  SearchRequest as ESSearchRequest,
+  MsearchMultisearchHeader,
+  SearchSearchRequestBody,
+} from '@elastic/elasticsearch/lib/api/types';
 import type { InferSearchResponseOf } from '@kbn/es-types';
 import type { KibanaRequest } from '@kbn/core/server';
 import { searchExcludedDataTiers } from '@kbn/observability-plugin/common/ui_settings_keys';
 import type { DataTier } from '@kbn/observability-shared-plugin/common';
 import { excludeTiersQuery } from '@kbn/observability-utils-common/es/queries/exclude_tiers_query';
-import type { QueryDslQueryContainer } from '@elastic/elasticsearch/lib/api/types';
 import type { InfraPluginRequestHandlerContext } from '../../types';
 import type { InfraBackendLibs } from '../infra_types';
 
-type RequiredParams = Omit<ESSearchRequest, 'index'> & {
+export type RequiredParams = Omit<ESSearchRequest, 'index'> & {
   size: number;
   track_total_hits: boolean | number;
 };
+
+export type MSearchParams = Omit<RequiredParams, 'allow_no_indices'>;
+
+interface TypedMSearchResponse<TDocument, TParams extends RequiredParams> {
+  responses: Array<InferSearchResponseOf<TDocument, TParams>>;
+}
 
 export type InfraMetricsClient = Awaited<ReturnType<typeof getInfraMetricsClient>>;
 
@@ -37,20 +46,12 @@ export async function getInfraMetricsClient({
   const excludedDataTiers = await uiSettings.client.get<DataTier[]>(searchExcludedDataTiers);
   const metricsIndices = await infraContext.getMetricsIndices();
 
-  const excludedQuery = excludedDataTiers.length
-    ? excludeTiersQuery(excludedDataTiers)[0].bool!.must_not!
-    : [];
+  const excludedQuery = excludedDataTiers.length ? excludeTiersQuery(excludedDataTiers) : undefined;
 
   return {
     search<TDocument, TParams extends RequiredParams>(
       searchParams: TParams
     ): Promise<InferSearchResponseOf<TDocument, TParams>> {
-      const searchFilter = searchParams.query?.bool?.must_not ?? [];
-
-      // This flattens arrays by one level, and non-array values can be added as well, so it all
-      // results in a nice [QueryDsl, QueryDsl, ...] array.
-      const mustNot = ([] as QueryDslQueryContainer[]).concat(searchFilter, excludedQuery);
-
       return framework.callWithRequest(
         context,
         'search',
@@ -59,15 +60,42 @@ export async function getInfraMetricsClient({
           ignore_unavailable: true,
           index: metricsIndices,
           query: {
-            ...searchParams.query,
             bool: {
-              ...searchParams.query?.bool,
-              must_not: mustNot,
+              filter: excludedQuery,
+              must: [searchParams.query],
             },
           },
         },
         request
       ) as Promise<any>;
+    },
+    msearch<TDocument, TParams extends MSearchParams>(
+      searchParams: TParams[]
+    ): Promise<TypedMSearchResponse<TDocument, TParams>> {
+      const searches = searchParams
+        .map((params) => {
+          const search: [MsearchMultisearchHeader, SearchSearchRequestBody] = [
+            {
+              index: metricsIndices,
+              preference: 'any',
+              ignore_unavailable: true,
+              expand_wildcards: ['open' as const, 'hidden' as const],
+            },
+            {
+              ...params,
+              query: {
+                bool: {
+                  filter: [params.query, ...(excludedQuery ? excludedQuery : [])].filter(Boolean),
+                },
+              },
+            },
+          ];
+
+          return search;
+        })
+        .flat();
+
+      return framework.callWithRequest(context, 'msearch', { searches }, request) as Promise<any>;
     },
   };
 }


### PR DESCRIPTION
## Summary

This PR makes the content dynamic based on the data present in the environment: 
- OTel only - just the Overview dashboard (the id passed)
- ECS only - just the Dashboard (the id passed)
- OTel + ECS toggle to switch between ECS/OTel - for now, the OTel Dashboard is the same on every page as we don't have other dashboards for OTel


https://github.com/user-attachments/assets/6684cadb-c817-455d-9aaf-2e958c3b5aef

