### PR TITLE
K8s nav dynamic & install integrations based on data

### DIFF
--- a/x-pack/platform/plugins/shared/observability_navigation/server/routes/internal/setup/route.ts
+++ b/x-pack/platform/plugins/shared/observability_navigation/server/routes/internal/setup/route.ts
@@ -34,18 +34,6 @@ const infraSideNavRoute = createServerRoute({
     const [fleetStart, core] = await Promise.all([plugins.fleet?.start(), context.core]);
     const packageClient = fleetStart?.packageService.asScoped(request);
 
-    const [installedPackage, ...navigationOverrides] = await Promise.all([
-      packageClient?.getInstallation(KUBERNETES),
-      core.savedObjects.client.get<NavigationOverridesSavedObject>(
-        OBSERVABILITY_NAVIGATION_OVERRIDES,
-        KUBERNETES
-      ),
-      core.savedObjects.client.get<NavigationOverridesSavedObject>(
-        OBSERVABILITY_NAVIGATION_OVERRIDES,
-        DOCKER
-      ),
-    ]);
-
     const metricbeatData = await core.elasticsearch.client.asCurrentUser.search({
       index: 'metrics-kubernetes*',
       ignore_unavailable: true,
@@ -85,102 +73,130 @@ const infraSideNavRoute = createServerRoute({
     const hasEcsData = metricbeatData?.hits?.total?.value !== 0;
     const hasOtelData = otelData?.hits?.total?.value !== 0;
 
-    // Maybe separate the ecs / otel cases in the future
-    // if ((hasEcsData || hasOtelData) && !installedPackage ) {
-    //   return [
-    //     {
-    //       id: KUBERNETES,
-    //       title: KUBERNETES,
-    //       subItems: [
-    //         {
-    //           id: 'kubernetes',
-    //           sideNavTitle: 'Add Kubernetes data',
-    //           sideNavOrder: 100,
-    //           type: 'dashboard',
-    //         },
-    //       ],
-    //     },
-    //   ];
-    // }
+    const [installedPackage, ...navigationOverrides] = await Promise.all([
+      packageClient?.getInstallation(KUBERNETES),
+      core.savedObjects.client.get<NavigationOverridesSavedObject>(
+        OBSERVABILITY_NAVIGATION_OVERRIDES,
+        KUBERNETES
+      ),
+      core.savedObjects.client.get<NavigationOverridesSavedObject>(
+        OBSERVABILITY_NAVIGATION_OVERRIDES,
+        DOCKER
+      ),
+    ]);
 
-    if (!installedPackage && !navigationOverrides) {
+    const packageInstalled = installedPackage ? [installedPackage] : [];
+    console.log('packageInstalled:', packageInstalled);
+
+    // Maybe separate the ecs / otel cases in the future
+    if ((hasEcsData || hasOtelData) && !installedPackage) {
+      // System package is always required
+      await packageClient?.ensureInstalledPackage({ pkgName: 'system' });
+      // Kubernetes package is required for both classic kubernetes and otel
+      await packageClient?.ensureInstalledPackage({ pkgName: 'kubernetes' });
+      const installedKubernetes = await packageClient?.getInstallation(KUBERNETES);
+      if (installedKubernetes) packageInstalled.push(installedKubernetes);
+      // Kubernetes otel package is required only for otel
+      if (hasOtelData) {
+        await packageClient?.ensureInstalledPackage({ pkgName: 'kubernetes_otel' });
+        const installedOtelKubernetes = await packageClient?.getInstallation('kubernetes_otel');
+        if (installedOtelKubernetes) packageInstalled.push(installedOtelKubernetes);
+      }
+    }
+
+    if ((!installedPackage || packageInstalled.length === 0) && !navigationOverrides) {
       return [];
     }
 
+    const otelInstalledPackage =
+      packageInstalled.find((pkg) => pkg.name === 'kubernetes_otel') || installedPackage;
+
     // Mock data simulating the installed package's items returned by installedPackage.installed_kibana
-    const mockInstalledPackage = installedPackage
-      ? [
-          {
-            id: 'kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.cronjob',
-            sideNavTitle: 'Cron jobs',
-            sideNavOrder: 900,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.statefulset',
-            sideNavTitle: 'Stateful sets',
-            sideNavOrder: 600,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.volume',
-            sideNavTitle: 'Volumes',
-            sideNavOrder: 500,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.pod',
-            sideNavTitle: 'Pods',
-            sideNavOrder: 300,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.deployment',
-            sideNavTitle: 'Deployments',
-            sideNavOrder: 400,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.daemonset',
-            sideNavTitle: 'Daemon sets',
-            sideNavOrder: 700,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.job',
-            sideNavTitle: 'Jobs',
-            sideNavOrder: 800,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.node',
-            sideNavTitle: 'Nodes',
-            sideNavOrder: 200,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c',
-            sideNavTitle: 'Overview',
-            sideNavOrder: 100,
-            type: 'dashboard',
-          },
-          {
-            id: 'kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013',
-            entityType: 'k8s.service',
-            sideNavTitle: 'Services',
-            sideNavOrder: 800,
-            type: 'dashboard',
-          },
-        ]
-      : [];
+    const mockInstalledPackage =
+      installedPackage && packageInstalled.length > 0
+        ? [
+            {
+              id: 'kubernetes-0a672d50-bcb1-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.cronjob',
+              sideNavTitle: 'Cron jobs',
+              sideNavOrder: 900,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-21694370-bcb2-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.statefulset',
+              sideNavTitle: 'Stateful sets',
+              sideNavOrder: 600,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-3912d9a0-bcb2-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.volume',
+              sideNavTitle: 'Volumes',
+              sideNavOrder: 500,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-3d4d9290-bcb1-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.pod',
+              sideNavTitle: 'Pods',
+              sideNavOrder: 300,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-5be46210-bcb1-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.deployment',
+              sideNavTitle: 'Deployments',
+              sideNavOrder: 400,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-85879010-bcb1-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.daemonset',
+              sideNavTitle: 'Daemon sets',
+              sideNavOrder: 700,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-9bf990a0-bcb1-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.job',
+              sideNavTitle: 'Jobs',
+              sideNavOrder: 800,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-b945b7b0-bcb1-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.node',
+              sideNavTitle: 'Nodes',
+              sideNavOrder: 200,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c',
+              sideNavTitle: 'Overview',
+              sideNavOrder: 100,
+              type: 'dashboard',
+            },
+            {
+              id: 'kubernetes-ff1b3850-bcb1-11ec-b64f-7dd6e8e82013',
+              entityType: 'k8s.service',
+              sideNavTitle: 'Services',
+              sideNavOrder: 800,
+              type: 'dashboard',
+            },
+            ...(otelInstalledPackage
+              ? [
+                  {
+                    id: 'kubernetes_otel-cluster-overview',
+                    entityType: 'k8s.overview',
+                    sideNavTitle: 'Overview (Otel)',
+                    sideNavOrder: 1000,
+                    type: 'dashboard',
+                  },
+                ]
+              : []),
+          ]
+        : [];
 
     const integrationSubItems =
       mockInstalledPackage

--- a/x-pack/platform/plugins/shared/observability_navigation/server/types.ts
+++ b/x-pack/platform/plugins/shared/observability_navigation/server/types.ts
@@ -16,8 +16,10 @@ export interface ObservabilityNavigationServer {
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ObservabilityNavigationPluginSetup {}
-// eslint-disable-next-line @typescript-eslint/no-empty-interface
-export interface ObservabilityNavigationPluginStart {}
+
+export interface ObservabilityNavigationPluginStart {
+  core: CoreStart;
+}
 
 // eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ObservabilityNavigationPluginSetupDependencies {}

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/add_kubernetes_data/add_kubernetes_data.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/add_kubernetes_data/add_kubernetes_data.tsx
@@ -1,0 +1,37 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import React from 'react';
+import { EuiLink } from '@elastic/eui';
+import type { ObservabilityOnboardingLocatorParams } from '@kbn/deeplinks-observability';
+import { OBSERVABILITY_ONBOARDING_LOCATOR } from '@kbn/deeplinks-observability';
+import { useKibana } from '@kbn/kibana-react-plugin/public';
+import type { SharePublicStart } from '@kbn/share-plugin/public/plugin';
+import { i18n } from '@kbn/i18n';
+
+const ADD_DATA_KUBERNETES_LABEL = i18n.translate('xpack.infra.metricsHeaderAddDataButtonLabel', {
+  defaultMessage: 'Add Kubernetes data',
+});
+
+export const AddKubernetesDataLink = () => {
+  const { share } = useKibana<{ share: SharePublicStart }>().services;
+  const onboardingLocator = share?.url.locators.get<ObservabilityOnboardingLocatorParams>(
+    OBSERVABILITY_ONBOARDING_LOCATOR
+  );
+
+  return (
+    <EuiLink
+      data-test-subj="infraAddDataLink"
+      href={onboardingLocator?.getRedirectUrl({
+        category: 'kubernetes',
+      })}
+      color="primary"
+    >
+      {ADD_DATA_KUBERNETES_LABEL}
+    </EuiLink>
+  );
+};

--- a/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/dashboard/render_dashboard.tsx
+++ b/x-pack/solutions/observability/plugins/infra/public/pages/metrics/dashboard/components/dashboard/render_dashboard.tsx
@@ -12,8 +12,12 @@ import type { DashboardApi, DashboardCreationOptions } from '@kbn/dashboard-plug
 import { KUBERNETES_DASHBOARD_LOCATOR_ID } from '@kbn/observability-shared-plugin/common';
 import type { SerializableRecord } from '@kbn/utility-types';
 import type { DashboardState } from '@kbn/dashboard-plugin/common';
+import { EuiLoadingSpinner } from '@elastic/eui';
+import { FETCH_STATUS } from '@kbn/observability-shared-plugin/public';
 import { useKibanaContextForPlugin } from '../../../../../hooks/use_kibana';
 import { useDatePickerContext } from '../../hooks/use_date_picker';
+import { AddKubernetesDataLink } from '../add_kubernetes_data/add_kubernetes_data';
+import { useFetchDashboardById } from '../../hooks/use_fetch_dashboard_by_id';
 
 export const RenderDashboard = ({ dashboardId }: { dashboardId: string }) => {
   const {
@@ -60,6 +64,15 @@ export const RenderDashboard = ({ dashboardId }: { dashboardId: string }) => {
     dashboard.setTimeRange({ from, to });
     dashboard.setQuery({ query: '', language: 'kuery' });
   }, [dashboard, dashboardId, from, to]);
+
+  const { data: dashboardData, status } = useFetchDashboardById(dashboardId);
+
+  if (!dashboardData && status === FETCH_STATUS.LOADING) {
+    return <EuiLoadingSpinner size="xl" />;
+  }
+  if (!dashboardData && status !== FETCH_STATUS.LOADING && dashboardId.startsWith('kubernetes')) {
+    return <AddKubernetesDataLink />;
+  }
 
   return (
     <DashboardRenderer


### PR DESCRIPTION
## Summary

The PR proves the dynamic functionality of the side nav based on different user k8s metrics data.

Case 1 Only OTel / Semconv data in the env 

https://github.com/user-attachments/assets/b2f3a69d-9eb2-4ad2-b2fb-336f86005824


Case 2 Only Metricbeat / ECS data

https://github.com/user-attachments/assets/af7107d5-62a4-47fa-bf0a-8855d5c129c8


Case 3 Mix of OTel / Semconv  & Metricbeat / ECS data


https://github.com/user-attachments/assets/c1490ca9-83d3-4c1c-aa47-2be7374b2917

Case 4 Add data case: 

![image](https://github.com/user-attachments/assets/16cb9b19-2fba-4c76-ac40-238180d81f69)
