### PR TITLE
[k8s PoC] Discover navigation to Infra dashboards

### DIFF
--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
@@ -20,7 +20,6 @@ import {
   EuiButtonEmpty,
   EuiCopy,
   useEuiTheme,
-  EuiButton,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useBoolean } from '@kbn/react-hooks';
@@ -159,11 +158,13 @@ export function CellActionsPopover({
               {filterOutText}
             </EuiButtonEmpty>
           </EuiFlexGroup>
-          <EuiButton href={infraProps.href} size="s" fill>
-            Go to {infraProps.label} dashboard
-          </EuiButton>
         </EuiPopoverFooter>
       ) : null}
+      <EuiPopoverFooter>
+        <EuiButtonEmpty href={infraProps.href} size="s" iconType="dashboardApp">
+          Go to {infraProps.label} dashboard
+        </EuiButtonEmpty>
+      </EuiPopoverFooter>
       <EuiPopoverFooter>
         <EuiCopy textToCopy={value}>
           {(copy) => (

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
@@ -20,6 +20,7 @@ import {
   EuiButtonEmpty,
   EuiCopy,
   useEuiTheme,
+  EuiButton,
 } from '@elastic/eui';
 import { css } from '@emotion/react';
 import { useBoolean } from '@kbn/react-hooks';
@@ -58,6 +59,13 @@ interface CellActionsPopoverProps {
   }) => ReactElement;
 }
 
+const infraRoutes = {
+  overview: {
+    href: 'metrics/entity/Kubernetes/Overview?dashboardId=kubernetes-f4dc26db-1b53-4ea2-a78b-1bfab8ea267c',
+    label: 'Kubernetes Overview',
+  },
+};
+
 export function CellActionsPopover({
   onFilter,
   property,
@@ -80,6 +88,11 @@ export function CellActionsPopover({
     onClickAriaLabel: openCellActionPopoverAriaText,
     'data-test-subj': `dataTableCellActionsPopover_${property}`,
   };
+
+  const infraProps =
+    property in infraRoutes
+      ? infraRoutes[property as keyof typeof infraRoutes]
+      : infraRoutes.overview;
 
   return (
     <EuiPopover
@@ -145,6 +158,9 @@ export function CellActionsPopover({
               {filterOutText}
             </EuiButtonEmpty>
           </EuiFlexGroup>
+          <EuiButton href={infraProps.href} size="s" fill>
+            Go to {infraProps.label} dashboard
+          </EuiButton>
         </EuiPopoverFooter>
       ) : null}
       <EuiPopoverFooter>

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/cell_actions_popover.tsx
@@ -105,6 +105,7 @@ export function CellActionsPopover({
       <EuiFlexGroup
         gutterSize="none"
         responsive={false}
+        justifyContent="spaceBetween"
         data-test-subj="dataTableCellActionPopoverTitle"
       >
         <EuiFlexItem style={{ maxWidth: '200px' }}>

--- a/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/utils.tsx
+++ b/src/platform/packages/shared/kbn-discover-contextual-components/src/data_types/logs/components/summary_column/utils.tsx
@@ -90,6 +90,7 @@ const getResourceBadgeComponent = (
   core: CoreStart,
   share?: SharePluginStart
 ): React.ComponentType<FieldBadgeWithActionsProps> => {
+  console.log('getResourceBadgeComponent', name, 'name');
   switch (name) {
     case EVENT_OUTCOME_FIELD:
       return EventOutcomeBadge;

--- a/src/platform/packages/shared/kbn-discover-utils/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/index.ts
@@ -32,6 +32,7 @@ export {
   convertValueToString,
   createLogsContextService,
   createTracesContextService,
+  createMetricsContextService,
   createApmErrorsContextService,
   createDegradedDocsControl,
   createStacktraceControl,
@@ -62,7 +63,12 @@ export {
   LogLevelBadge,
 } from './src';
 
-export type { LogsContextService, TracesContextService, ApmErrorsContextService } from './src';
+export type {
+  LogsContextService,
+  TracesContextService,
+  ApmErrorsContextService,
+  MetricsContextService,
+} from './src';
 
 export * from './src/types';
 

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/constants.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/constants.ts
@@ -89,7 +89,14 @@ export const RESOURCE_FIELDS = [
   fieldConstants.ORCHESTRATOR_CLUSTER_ID_FIELD,
   fieldConstants.CONTAINER_ID_FIELD,
   fieldConstants.AGENT_NAME_FIELD,
+  'kubernetes.container.name',
 ] as const;
+export const METRIC_FIELDS = [
+  'kubernetes.container.name',
+  'k8s.container.name',
+  'kubernetes.pod.name',
+  'k8s.pod.name',
+];
 export const TRACE_FIELDS = [
   fieldConstants.SERVICE_NAME_FIELD,
   fieldConstants.EVENT_OUTCOME_FIELD,

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_available_resource_fields.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/logs/utils/get_available_resource_fields.ts
@@ -36,6 +36,7 @@ const AVAILABLE_RESOURCE_FIELDS: Array<Array<keyof ResourceFields>> = [
 
 export const getAvailableResourceFields = (resourceDoc: ResourceFields) =>
   AVAILABLE_RESOURCE_FIELDS.reduce((acc, fields) => {
+    console.log('getAvailableResourceFields', fields, resourceDoc);
     const field = fields.find((fieldName) => resourceDoc[fieldName]);
     if (field) {
       acc.push(field);

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/metrics/index.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/metrics/index.ts
@@ -7,7 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './logs';
-export * from './traces';
-export * from './apm';
-export * from './metrics';
+export * from './metrics_context_service';

--- a/src/platform/packages/shared/kbn-discover-utils/src/data_types/metrics/metrics_context_service.ts
+++ b/src/platform/packages/shared/kbn-discover-utils/src/data_types/metrics/metrics_context_service.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { ApmSourceAccessPluginStart } from '@kbn/apm-sources-access-plugin/public';
+import { createRegExpPatternFrom, testPatternAgainstAllowedList } from '@kbn/data-view-utils';
+import { containsIndexPattern } from '../../utils';
+
+export interface MetricsContextService {
+  getAllMetricsIndexPattern(): string;
+  isMetricsIndexPattern(indexPattern: unknown): boolean;
+  containsMetricsIndexPattern(indexPattern: unknown): boolean;
+}
+
+export interface MetricsContextServiceDeps {
+  apmSourcesAccess?: ApmSourceAccessPluginStart;
+}
+
+export const DEFAULT_ALLOWED_METRICS_BASE_PATTERNS = ['metrics', 'metricbeat'];
+
+export const DEFAULT_ALLOWED_METRICS_BASE_PATTERNS_REGEXP = createRegExpPatternFrom(
+  DEFAULT_ALLOWED_METRICS_BASE_PATTERNS,
+  'data'
+);
+
+export const createMetricsContextService = async ({
+  apmSourcesAccess,
+}: MetricsContextServiceDeps): Promise<MetricsContextService> => {
+  if (!apmSourcesAccess) {
+    return defaultMetricsContextService;
+  }
+
+  try {
+    const indices = await apmSourcesAccess.getApmIndices();
+
+    if (!indices) {
+      return defaultMetricsContextService;
+    }
+
+    const { transaction, span } = indices;
+    const allIndices = getAllIndices(transaction, span);
+    const uniqueIndices = Array.from(new Set(allIndices));
+
+    const metrics = uniqueIndices.join();
+    const allowedDataSources = [createRegExpPatternFrom(uniqueIndices, 'data')];
+
+    return getMetricsContextService(metrics, allowedDataSources);
+  } catch (error) {
+    return defaultMetricsContextService;
+  }
+};
+
+function getAllIndices(transaction: string, span: string) {
+  return [transaction, span]
+    .flatMap((index) => index.split(','))
+    .concat(DEFAULT_ALLOWED_METRICS_BASE_PATTERNS);
+}
+
+export const getMetricsContextService = (metrics: string, allowedDataSources: RegExp[]) => ({
+  getAllMetricsIndexPattern: () => metrics,
+  isMetricsIndexPattern: testPatternAgainstAllowedList(allowedDataSources),
+  containsMetricsIndexPattern: containsIndexPattern(allowedDataSources),
+});
+
+const defaultMetricsContextService = getMetricsContextService(
+  DEFAULT_ALLOWED_METRICS_BASE_PATTERNS.join(),
+  [DEFAULT_ALLOWED_METRICS_BASE_PATTERNS_REGEXP]
+);

--- a/src/platform/plugins/shared/discover/common/constants.ts
+++ b/src/platform/plugins/shared/discover/common/constants.ts
@@ -37,3 +37,4 @@ export const TABS_STATE_URL_KEY = '_t';
  * Product feature IDs
  */
 export const TRACES_PRODUCT_FEATURE_ID = 'discover:traces';
+export const METRICS_PRODUCT_FEATURE_ID = 'discover:metrics';

--- a/src/platform/plugins/shared/discover/public/components/data_types/metrics/summary_column.tsx
+++ b/src/platform/plugins/shared/discover/public/components/data_types/metrics/summary_column.tsx
@@ -1,0 +1,47 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import React from 'react';
+import { getShouldShowFieldHandler } from '@kbn/discover-utils';
+import type { DataView } from '@kbn/data-views-plugin/common';
+import type {
+  AllSummaryColumnProps,
+  SummaryColumnProps,
+} from '@kbn/discover-contextual-components';
+import { LazySummaryColumn } from '@kbn/discover-contextual-components';
+import type { CellRenderersExtensionParams } from '../../../context_awareness';
+import { useDiscoverServices } from '../../../hooks/use_discover_services';
+
+export type SummaryColumnGetterDeps = CellRenderersExtensionParams;
+
+const SummaryColumn = (props: Omit<AllSummaryColumnProps, 'core' | 'share'>) => {
+  const { share, core } = useDiscoverServices();
+  return <LazySummaryColumn {...props} share={share} core={core} />;
+};
+
+export const getMetricsSummaryColumn = (params: SummaryColumnGetterDeps) => {
+  const { actions, dataView, density, rowHeight } = params;
+  const shouldShowFieldHandler = createGetShouldShowFieldHandler(dataView);
+
+  return (props: Omit<SummaryColumnProps, 'core' | 'share'>) => (
+    <SummaryColumn
+      {...props}
+      isMetricsSummary
+      density={density}
+      onFilter={actions.addFilter}
+      rowHeight={rowHeight}
+      shouldShowFieldHandler={shouldShowFieldHandler}
+    />
+  );
+};
+
+const createGetShouldShowFieldHandler = (dataView: DataView) => {
+  const dataViewFields = dataView.fields.getAll().map((fld) => fld.name);
+  return getShouldShowFieldHandler(dataViewFields, dataView, true);
+};

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/accessors/get_cell_renderers.tsx
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/accessors/get_cell_renderers.tsx
@@ -6,8 +6,12 @@
  * your election, the "Elastic License 2.0", the "GNU Affero General Public
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
+import { SOURCE_COLUMN } from '@kbn/unified-data-table';
+import { getMetricsSummaryColumn } from '../../../../../components/data_types/metrics/summary_column';
+import type { DataSourceProfileProvider } from '../../../../profiles';
 
-export * from './logs';
-export * from './traces';
-export * from './apm';
-export * from './metrics';
+export const getCellRenderers: DataSourceProfileProvider['profile']['getCellRenderers'] =
+  (prev) => (params) => ({
+    ...prev(params),
+    [SOURCE_COLUMN]: getMetricsSummaryColumn(params),
+  });

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/accessors/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/accessors/index.ts
@@ -7,7 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './logs';
-export * from './traces';
-export * from './apm';
-export * from './metrics';
+export * from './get_cell_renderers';

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/index.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/index.ts
@@ -7,7 +7,4 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
-export * from './logs';
-export * from './traces';
-export * from './apm';
-export * from './metrics';
+export { createMetricsDataSourceProfileProvider } from './profile';

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.test.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.test.ts
@@ -1,0 +1,110 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import type { DataView } from '@kbn/data-views-plugin/common';
+import {
+  DataSourceCategory,
+  type DataSourceProfileProviderParams,
+  SolutionType,
+  type RootContext,
+} from '../../../profiles';
+import { DataSourceType, createDataViewDataSource } from '../../../../../common/data_sources';
+import { createMetricsDataSourceProfileProvider } from './profile';
+import { createContextAwarenessMocks } from '../../../__mocks__';
+import type { ContextWithProfileId } from '../../../profile_service';
+import { OBSERVABILITY_ROOT_PROFILE_ID } from '../consts';
+
+const mockServices = createContextAwarenessMocks().profileProviderServices;
+
+describe('tracesDataSourceProfileProvider', () => {
+  const tracesDataSourceProfileProvider = createMetricsDataSourceProfileProvider(mockServices);
+
+  const RESOLUTION_MATCH = {
+    isMatch: true,
+    context: { category: DataSourceCategory.Traces },
+  };
+
+  const RESOLUTION_MISMATCH = {
+    isMatch: false,
+  };
+
+  const ROOT_CONTEXT: ContextWithProfileId<RootContext> = {
+    profileId: OBSERVABILITY_ROOT_PROFILE_ID,
+    solutionType: SolutionType.Observability,
+  };
+
+  it('should match when the index is for traces', () => {
+    expect(
+      tracesDataSourceProfileProvider.resolve({
+        rootContext: ROOT_CONTEXT,
+        dataSource: createDataViewDataSource({ dataViewId: 'apm_static_data_view_id_default' }),
+        dataView: {
+          getIndexPattern: () => 'traces-*',
+        } as unknown as DataView,
+      } as DataSourceProfileProviderParams)
+    ).toEqual(RESOLUTION_MATCH);
+
+    expect(
+      tracesDataSourceProfileProvider.resolve({
+        rootContext: ROOT_CONTEXT,
+        dataSource: createDataViewDataSource({ dataViewId: 'apm_static_data_view_id_custom_view' }),
+        dataView: {
+          getIndexPattern: () => 'traces-*',
+        } as unknown as DataView,
+      } as DataSourceProfileProviderParams)
+    ).toEqual(RESOLUTION_MATCH);
+
+    expect(
+      tracesDataSourceProfileProvider.resolve({
+        rootContext: ROOT_CONTEXT,
+        dataSource: createDataViewDataSource({ dataViewId: 'other_view_id' }),
+        dataView: { getIndexPattern: () => 'traces-*' } as unknown as DataView,
+      } as DataSourceProfileProviderParams)
+    ).toEqual(RESOLUTION_MATCH);
+
+    expect(
+      tracesDataSourceProfileProvider.resolve({
+        rootContext: ROOT_CONTEXT,
+        dataSource: { type: DataSourceType.Esql },
+        query: { esql: 'FROM traces' },
+      } as DataSourceProfileProviderParams)
+    ).toEqual(RESOLUTION_MATCH);
+  });
+
+  it('should NOT match when the index is not for traces', () => {
+    expect(
+      tracesDataSourceProfileProvider.resolve({
+        rootContext: ROOT_CONTEXT,
+        dataSource: { type: DataSourceType.Esql },
+        query: { esql: 'FROM logs' },
+      } as DataSourceProfileProviderParams)
+    ).toEqual(RESOLUTION_MISMATCH);
+
+    expect(
+      tracesDataSourceProfileProvider.resolve({
+        rootContext: ROOT_CONTEXT,
+        dataSource: createDataViewDataSource({ dataViewId: 'other_logs_view_id' }),
+        dataView: { getIndexPattern: () => 'logs-*' } as unknown as DataView,
+      } as DataSourceProfileProviderParams)
+    ).toEqual(RESOLUTION_MISMATCH);
+  });
+
+  it('should NOT match when the solutionType is NOT Observability', () => {
+    expect(
+      tracesDataSourceProfileProvider.resolve({
+        rootContext: {
+          profileId: 'security-root-profile',
+          solutionType: SolutionType.Security,
+        },
+        dataSource: createDataViewDataSource({ dataViewId: 'other_view_id' }),
+        dataView: { getIndexPattern: () => 'traces-*' } as unknown as DataView,
+      } as DataSourceProfileProviderParams)
+    ).toEqual(RESOLUTION_MISMATCH);
+  });
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/observability/metrics_data_source_profile/profile.ts
@@ -1,0 +1,58 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the "Elastic License
+ * 2.0", the "GNU Affero General Public License v3.0 only", and the "Server Side
+ * Public License v 1"; you may not use this file except in compliance with, at
+ * your election, the "Elastic License 2.0", the "GNU Affero General Public
+ * License v3.0 only", or the "Server Side Public License, v 1".
+ */
+
+import { METRICS_PRODUCT_FEATURE_ID } from '../../../../../common/constants';
+import {
+  SolutionType,
+  DataSourceCategory,
+  type DataSourceProfileProvider,
+} from '../../../profiles';
+import { extractIndexPatternFrom } from '../../extract_index_pattern_from';
+import type { ProfileProviderServices } from '../../profile_provider_services';
+import { getCellRenderers } from './accessors';
+// change this to observability-metrics-data-source-profile
+const OBSERVABILITY_METRICS_DATA_SOURCE_PROFILE_ID = 'observability-metrics-data-source-profile';
+
+export const createMetricsDataSourceProfileProvider = ({
+  metricsContextService,
+}: ProfileProviderServices): DataSourceProfileProvider => ({
+  profileId: OBSERVABILITY_METRICS_DATA_SOURCE_PROFILE_ID,
+  restrictedToProductFeature: METRICS_PRODUCT_FEATURE_ID,
+  profile: {
+    getDefaultAppState: (prev) => (params) => ({
+      ...prev(params),
+      columns: [
+        {
+          name: '@timestamp',
+          width: 212,
+        },
+        {
+          name: '_source',
+        },
+      ],
+      rowHeight: 5,
+    }),
+    getCellRenderers,
+  },
+  resolve: (params) => {
+    if (
+      params.rootContext.solutionType === SolutionType.Observability &&
+      metricsContextService.containsMetricsIndexPattern(extractIndexPatternFrom(params))
+    ) {
+      return {
+        isMatch: true,
+        context: {
+          category: DataSourceCategory.Metrics,
+        },
+      };
+    }
+
+    return { isMatch: false };
+  },
+});

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/profile_provider_services.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/profile_provider_services.ts
@@ -7,6 +7,7 @@
  * License v3.0 only", or the "Server Side Public License, v 1".
  */
 
+import type { MetricsContextService } from '@kbn/discover-utils';
 import {
   createLogsContextService,
   type LogsContextService,
@@ -14,6 +15,7 @@ import {
   type TracesContextService,
   createApmErrorsContextService,
   type ApmErrorsContextService,
+  createMetricsContextService,
 } from '@kbn/discover-utils';
 
 import type { LogsDataAccessPluginStart } from '@kbn/logs-data-access-plugin/public';
@@ -38,6 +40,7 @@ export interface ProfileProviderServices extends DiscoverServices {
   logsContextService: LogsContextService;
   tracesContextService: TracesContextService;
   apmErrorsContextService: ApmErrorsContextService;
+  metricsContextService: MetricsContextService;
 }
 
 /**
@@ -57,6 +60,9 @@ export const createProfileProviderServices = async (
       apmSourcesAccess: discoverServices.apmSourcesAccess,
     }),
     apmErrorsContextService: await createApmErrorsContextService({
+      apmSourcesAccess: discoverServices.apmSourcesAccess,
+    }),
+    metricsContextService: await createMetricsContextService({
       apmSourcesAccess: discoverServices.apmSourcesAccess,
     }),
   };

--- a/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profile_providers/register_profile_providers.ts
@@ -30,6 +30,7 @@ import { createDeprecationLogsDataSourceProfileProvider } from './common/depreca
 import { createClassicNavRootProfileProvider } from './common/classic_nav_root_profile';
 import { createObservabilityDocumentProfileProviders } from './observability/observability_profile_providers';
 import { createSecurityDocumentProfileProvider } from './security/security_document_profile';
+import { createMetricsDataSourceProfileProvider } from './observability/metrics_data_source_profile';
 
 /**
  * Register profile providers for root, data source, and document contexts to the profile profile services
@@ -149,6 +150,7 @@ const createDataSourceProfileProviders = (providerServices: ProfileProviderServi
   createExampleDataSourceProfileProvider(),
   createDeprecationLogsDataSourceProfileProvider(),
   createTracesDataSourceProfileProvider(providerServices),
+  createMetricsDataSourceProfileProvider(providerServices),
   ...createObservabilityLogsDataSourceProfileProviders(providerServices),
 ];
 

--- a/src/platform/plugins/shared/discover/public/context_awareness/profiles/data_source_profile.ts
+++ b/src/platform/plugins/shared/discover/public/context_awareness/profiles/data_source_profile.ts
@@ -22,6 +22,7 @@ export enum DataSourceCategory {
   Traces = 'traces',
   Logs = 'logs',
   Default = 'default',
+  Metrics = 'metrics',
 }
 
 /**


### PR DESCRIPTION
## Summary

Adds navigation to k8s dashboards in infra from discover

## How to test
1. Make sure you have the observability space
2. Go to discover and create a dataview for metrics-*
3. Click into the summary and navigate into the dashboard

## Open Questions

- [ ] Should we create an additional discover profile for this?
- [ ] Do we need a product feature ID?

## To-Do
- [ ] Create custom CellPopoverOptions for metrics
- [ ] Add metric fields type
- [ ] Improve available metric fields to filter from
- [ ] Choose dashboard based on property





