### PR TITLE
feat(apm): refine service map dashboard panel design

### DIFF
--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/add_to_dashboard_button.tsx
@@ -5,13 +5,9 @@
  * 2.0.
  */
 
-import React, { useCallback, useMemo, useState } from 'react';
-import {
-  EuiButtonIcon,
-  EuiContextMenuPanel,
-  EuiContextMenuItem,
-  EuiPopover,
-} from '@elastic/eui';
+import React, { useCallback, useState } from 'react';
+import type { SerializedStyles } from '@emotion/react';
+import { EuiButtonIcon, EuiContextMenuItem, EuiContextMenuPanel, EuiPopover } from '@elastic/eui';
 import { i18n } from '@kbn/i18n';
 import type { EmbeddablePackageState } from '@kbn/embeddable-plugin/public';
 import type { Filter } from '@kbn/es-query';
@@ -38,6 +34,8 @@ interface AddToDashboardButtonProps {
   viewFilters: ServiceMapViewFilters;
   /** Current find-in-page query — captured into the dashboard panel state. */
   searchQuery: string;
+  /** Shared toolbar icon sizing so the button matches the surrounding map controls. */
+  controlIconCss?: SerializedStyles;
 }
 
 /** Serialize a single string value as a quoted KQL phrase. */
@@ -152,6 +150,7 @@ export function AddToDashboardButton({
   mapOrientation,
   viewFilters,
   searchQuery,
+  controlIconCss,
 }: AddToDashboardButtonProps) {
   const { services } = useKibana<ApmPluginStartDeps>();
   const embeddable = services?.embeddable;
@@ -240,50 +239,50 @@ export function AddToDashboardButton({
     defaultMessage: 'Service map',
   });
 
-  const menuLabel = i18n.translate('xpack.apm.serviceMap.panelActions.menuLabel', {
-    defaultMessage: 'More actions',
+  const copyToDashboardLabel = i18n.translate('xpack.apm.serviceMap.copyToDashboardLabel', {
+    defaultMessage: 'Copy to dashboard',
   });
 
-  const menuItems = useMemo(
-    () => [
-      <EuiContextMenuItem
-        key="copyToDashboard"
-        icon="addToDashboard"
-        onClick={() => {
-          setIsMenuOpen(false);
-          setIsModalOpen(true);
-        }}
-        data-test-subj="apmServiceMapCopyToDashboardMenuItem"
-      >
-        {i18n.translate('xpack.apm.serviceMap.copyToDashboardMenuItem', {
-          defaultMessage: 'Copy to dashboard',
-        })}
-      </EuiContextMenuItem>,
-    ],
-    []
-  );
+  const menuLabel = i18n.translate('xpack.apm.serviceMap.panelActions.menuLabel', {
+    defaultMessage: 'Share',
+  });
+
+  const menuItems = [
+    <EuiContextMenuItem
+      key="copyToDashboard"
+      icon="addToDashboard"
+      onClick={() => {
+        setIsMenuOpen(false);
+        setIsModalOpen(true);
+      }}
+      data-test-subj="apmServiceMapCopyToDashboardMenuItem"
+    >
+      {copyToDashboardLabel}
+    </EuiContextMenuItem>,
+  ];
 
   return (
     <>
       <EuiPopover
-        anchorPosition="downRight"
+        anchorPosition="rightUp"
         panelPaddingSize="none"
         isOpen={isMenuOpen}
         closePopover={() => setIsMenuOpen(false)}
         button={
           <EuiButtonIcon
-            iconType="boxesHorizontal"
+            iconType="share"
+            display="empty"
             color="text"
-            display="base"
             size="s"
             aria-label={menuLabel}
             title={menuLabel}
             onClick={() => setIsMenuOpen((open) => !open)}
-            data-test-subj="apmServiceMapPanelActionsButton"
+            data-test-subj="apmServiceMapShareButton"
+            css={controlIconCss}
           />
         }
       >
-        <EuiContextMenuPanel size="s" items={menuItems} />
+        <EuiContextMenuPanel items={menuItems} />
       </EuiPopover>
       {isModalOpen && (
         <SavedObjectSaveModalDashboard

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/graph.tsx
@@ -626,11 +626,13 @@ function GraphInner({
             <Background gap={24} size={1} color={euiTheme.colors.lightShade} />
             <Panel position="top-left" css={topLeftToolbarStyles}>
               <div css={topLeftToolbarColumnStyles}>
-                <ServiceMapOptionsPanelToggle
-                  isExpanded={panelExpanded}
-                  onExpandedChange={setPanelExpanded}
-                  hasActiveControls={hasActiveControls}
-                />
+                {!isEmbedded && (
+                  <ServiceMapOptionsPanelToggle
+                    isExpanded={panelExpanded}
+                    onExpandedChange={setPanelExpanded}
+                    hasActiveControls={hasActiveControls}
+                  />
+                )}
                 <EuiPanel
                   hasBorder
                   hasShadow={false}
@@ -709,6 +711,36 @@ function GraphInner({
                     )}
                   </EuiFlexGroup>
                 </EuiPanel>
+                {!isEmbedded && (
+                  <EuiPanel
+                    hasBorder
+                    hasShadow={false}
+                    paddingSize="none"
+                    borderRadius="m"
+                    grow={false}
+                  >
+                    <EuiFlexGroup
+                      direction="column"
+                      gutterSize="none"
+                      alignItems="center"
+                      justifyContent="center"
+                      responsive={false}
+                    >
+                      <AddToDashboardButton
+                        environment={environment}
+                        kuery={kuery}
+                        start={start}
+                        end={end}
+                        serviceName={serviceName}
+                        serviceGroupId={serviceGroupId}
+                        mapOrientation={mapOrientation}
+                        viewFilters={viewFilters}
+                        searchQuery={searchQuery}
+                        controlIconCss={mapToolbarControlIconCss}
+                      />
+                    </EuiFlexGroup>
+                  </EuiPanel>
+                )}
                 <EuiPanel
                   hasBorder
                   hasShadow={false}
@@ -719,7 +751,7 @@ function GraphInner({
                   <ServiceMapLegend controlIconCss={mapToolbarControlIconCss} />
                 </EuiPanel>
               </div>
-              {panelExpanded && (
+              {!isEmbedded && panelExpanded && (
                 <ServiceMapOptionsPanel
                   nodes={nodesAfterFilters}
                   filterOptionCounts={filterOptionCounts}
@@ -746,21 +778,6 @@ function GraphInner({
                 />
               )}
             </Panel>
-            {!isEmbedded && (
-              <Panel position="top-right">
-                <AddToDashboardButton
-                  environment={environment}
-                  kuery={kuery}
-                  start={start}
-                  end={end}
-                  serviceName={serviceName}
-                  serviceGroupId={serviceGroupId}
-                  mapOrientation={mapOrientation}
-                  viewFilters={viewFilters}
-                  searchQuery={searchQuery}
-                />
-              </Panel>
-            )}
             {!isEmbedded && <ServiceMapMinimap />}
           </ReactFlow>
           <MapPopover

--- a/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_options_panel.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/components/app/service_map/service_map_options_panel.tsx
@@ -38,7 +38,7 @@ import { ServiceMapFindInPage } from './service_map_find_in_page';
 
 export type ServiceMapOrientation = 'horizontal' | 'vertical';
 
-const CONNECTION_FILTER_OPTIONS: { value: ConnectionFilter; label: string }[] = [
+export const CONNECTION_FILTER_OPTIONS: { value: ConnectionFilter; label: string }[] = [
   {
     value: 'orphaned',
     label: i18n.translate('xpack.apm.serviceMap.controls.connectionOrphaned', {
@@ -53,7 +53,7 @@ const CONNECTION_FILTER_OPTIONS: { value: ConnectionFilter; label: string }[] = 
   },
 ];
 
-const ALERT_STATUS_OPTIONS: { value: AlertStatus; label: string }[] = [
+export const ALERT_STATUS_OPTIONS: { value: AlertStatus; label: string }[] = [
   {
     value: ALERT_STATUS_ACTIVE,
     label: i18n.translate('xpack.apm.serviceMap.controls.alertStatusActive', {
@@ -80,7 +80,7 @@ const ALERT_STATUS_OPTIONS: { value: AlertStatus; label: string }[] = [
   },
 ];
 
-const SLO_STATUS_OPTIONS: { value: SloStatus; label: string }[] = [
+export const SLO_STATUS_OPTIONS: { value: SloStatus; label: string }[] = [
   {
     value: 'healthy',
     label: i18n.translate('xpack.apm.serviceMap.controls.sloHealthy', {
@@ -107,7 +107,7 @@ const SLO_STATUS_OPTIONS: { value: SloStatus; label: string }[] = [
   },
 ];
 
-const ANOMALY_SEVERITY_OPTIONS: { value: ML_ANOMALY_SEVERITY; label: string }[] = [
+export const ANOMALY_SEVERITY_OPTIONS: { value: ML_ANOMALY_SEVERITY; label: string }[] = [
   {
     value: ML_ANOMALY_SEVERITY.CRITICAL,
     label: i18n.translate('xpack.apm.serviceMap.controls.anomalySeverityCritical', {

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_editor_flyout.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_editor_flyout.tsx
@@ -8,6 +8,7 @@
 import {
   EuiButton,
   EuiButtonEmpty,
+  EuiButtonGroup,
   EuiComboBox,
   EuiFlexGroup,
   EuiFlexItem,
@@ -16,16 +17,21 @@ import {
   EuiFlyoutHeader,
   EuiForm,
   EuiFormRow,
+  EuiHorizontalRule,
   EuiLink,
   EuiSkeletonText,
   EuiSwitch,
+  EuiText,
   EuiTitle,
+  htmlIdGenerator,
 } from '@elastic/eui';
-import type { EuiComboBoxOptionOption } from '@elastic/eui';
+import type { EuiButtonGroupOptionProps, EuiComboBoxOptionOption } from '@elastic/eui';
 import React, { useCallback, useMemo, useState } from 'react';
 import { i18n } from '@kbn/i18n';
 import { FormattedMessage } from '@kbn/i18n-react';
 import { SERVICE_NAME, SERVICE_ENVIRONMENT } from '@kbn/apm-types';
+import type { AlertStatus } from '@kbn/rule-data-utils';
+import type { ML_ANOMALY_SEVERITY } from '@kbn/ml-anomaly-utils/anomaly_severity';
 import type { Query, TimeRange } from '@kbn/es-query';
 import datemath from '@kbn/datemath';
 import {
@@ -34,7 +40,16 @@ import {
   getEnvironmentLabel,
 } from '../../../common/environment_filter_values';
 import type { Environment } from '../../../common/environment_rt';
+import type { SloStatus } from '../../../common/service_inventory';
 import type { ServiceMapEmbeddableState } from '../../../server/lib/embeddables/service_map_embeddable_schema';
+import type { ConnectionFilter } from '../../components/app/service_map/apply_service_map_visibility';
+import {
+  ALERT_STATUS_OPTIONS,
+  ANOMALY_SEVERITY_OPTIONS,
+  CONNECTION_FILTER_OPTIONS,
+  SLO_STATUS_OPTIONS,
+} from '../../components/app/service_map/service_map_options_panel';
+import type { ServiceMapOrientation } from '../../components/app/service_map/service_map_options_panel';
 import type { EmbeddableDeps } from '../types';
 import { useSuggestions } from './use_suggestions';
 import { useAdHocApmDataView } from '../../hooks/use_adhoc_apm_data_view';
@@ -118,6 +133,54 @@ function KueryInput({ kuery, onChange, deps }: KueryInputProps) {
   );
 }
 
+interface FilterComboBoxProps<T extends string> {
+  label: string;
+  placeholder: string;
+  options: ReadonlyArray<{ value: T; label: string }>;
+  selected: T[];
+  onChange: (next: T[]) => void;
+  dataTestSubj: string;
+}
+
+/** Static multi-select for a single persisted map filter. No live counts — the flyout has no map data. */
+function FilterComboBox<T extends string>({
+  label,
+  placeholder,
+  options,
+  selected,
+  onChange,
+  dataTestSubj,
+}: FilterComboBoxProps<T>) {
+  const comboOptions = useMemo<Array<EuiComboBoxOptionOption<T>>>(
+    () => options.map((opt) => ({ label: opt.label, value: opt.value })),
+    [options]
+  );
+  const selectedOptions = useMemo<Array<EuiComboBoxOptionOption<T>>>(
+    () =>
+      selected.map((value) => {
+        const opt = options.find((o) => o.value === value);
+        return { label: opt?.label ?? value, value };
+      }),
+    [options, selected]
+  );
+
+  return (
+    <EuiFormRow label={label} fullWidth>
+      <EuiComboBox
+        aria-label={label}
+        placeholder={placeholder}
+        options={comboOptions}
+        selectedOptions={selectedOptions}
+        onChange={(changed) => onChange(changed.map((s) => (s.value ?? s.label) as T))}
+        fullWidth
+        compressed
+        isClearable
+        data-test-subj={dataTestSubj}
+      />
+    </EuiFormRow>
+  );
+}
+
 export interface ServiceMapEditorFlyoutProps {
   onCancel: () => void;
   onSave: (state: ServiceMapEmbeddableState) => void;
@@ -180,6 +243,45 @@ export function ServiceMapEditorFlyout({
   const [serviceName, setServiceName] = useState(initialState?.service_name ?? '');
   const [syncWithDashboardFilters, setSyncWithDashboardFilters] = useState<boolean>(
     initialState?.sync_with_dashboard_filters ?? false
+  );
+
+  const [connectionFilter, setConnectionFilter] = useState<ConnectionFilter[]>(
+    (initialState?.connection_filter ?? []) as ConnectionFilter[]
+  );
+  const [alertStatusFilter, setAlertStatusFilter] = useState<AlertStatus[]>(
+    (initialState?.alert_status_filter ?? []) as AlertStatus[]
+  );
+  const [sloStatusFilter, setSloStatusFilter] = useState<SloStatus[]>(
+    (initialState?.slo_status_filter ?? []) as SloStatus[]
+  );
+  const [anomalySeverityFilter, setAnomalySeverityFilter] = useState<ML_ANOMALY_SEVERITY[]>(
+    (initialState?.anomaly_severity_filter ?? []) as ML_ANOMALY_SEVERITY[]
+  );
+  const [mapOrientation, setMapOrientation] = useState<ServiceMapOrientation>(
+    initialState?.map_orientation ?? 'horizontal'
+  );
+
+  const orientationIdPrefix = useMemo(() => htmlIdGenerator()(), []);
+  const orientationOptions: EuiButtonGroupOptionProps[] = useMemo(
+    () => [
+      {
+        id: `${orientationIdPrefix}horizontal`,
+        label: i18n.translate('xpack.apm.serviceMapEditor.layoutHorizontal', {
+          defaultMessage: 'Horizontal',
+        }),
+        iconType: 'arrowRight',
+        'data-test-subj': 'apmServiceMapEditorLayoutHorizontal',
+      },
+      {
+        id: `${orientationIdPrefix}vertical`,
+        label: i18n.translate('xpack.apm.serviceMapEditor.layoutVertical', {
+          defaultMessage: 'Vertical',
+        }),
+        iconType: 'arrowDown',
+        'data-test-subj': 'apmServiceMapEditorLayoutVertical',
+      },
+    ],
+    [orientationIdPrefix]
   );
 
   const [selectedServiceOption, setSelectedServiceOption] = useState<
@@ -256,9 +358,33 @@ export function ServiceMapEditorFlyout({
       kuery: kuery.trim() ? kuery : undefined,
       service_name: serviceName || undefined,
       sync_with_dashboard_filters: syncWithDashboardFilters,
+      connection_filter: connectionFilter.length
+        ? (connectionFilter as ServiceMapEmbeddableState['connection_filter'])
+        : undefined,
+      alert_status_filter: alertStatusFilter.length
+        ? (alertStatusFilter as ServiceMapEmbeddableState['alert_status_filter'])
+        : undefined,
+      slo_status_filter: sloStatusFilter.length
+        ? (sloStatusFilter as ServiceMapEmbeddableState['slo_status_filter'])
+        : undefined,
+      anomaly_severity_filter: anomalySeverityFilter.length
+        ? (anomalySeverityFilter as ServiceMapEmbeddableState['anomaly_severity_filter'])
+        : undefined,
+      map_orientation: mapOrientation,
     };
     onSave(state);
-  }, [environment, kuery, serviceName, syncWithDashboardFilters, onSave]);
+  }, [
+    environment,
+    kuery,
+    serviceName,
+    syncWithDashboardFilters,
+    connectionFilter,
+    alertStatusFilter,
+    sloStatusFilter,
+    anomalySeverityFilter,
+    mapOrientation,
+    onSave,
+  ]);
 
   return (
     <div style={serviceMapFlyoutShellStyle}>
@@ -346,6 +472,110 @@ export function ServiceMapEditorFlyout({
           </EuiFormRow>
 
           <KueryInput kuery={kuery} onChange={setKuery} deps={deps} />
+
+          <EuiHorizontalRule margin="m" />
+
+          <EuiText size="xs">
+            <h3>
+              {i18n.translate('xpack.apm.serviceMapEditor.filtersHeading', {
+                defaultMessage: 'Filters',
+              })}
+            </h3>
+          </EuiText>
+
+          <FilterComboBox<ConnectionFilter>
+            label={i18n.translate('xpack.apm.serviceMapEditor.dependenciesFilterLabel', {
+              defaultMessage: 'Dependencies',
+            })}
+            placeholder={i18n.translate(
+              'xpack.apm.serviceMapEditor.dependenciesFilterPlaceholder',
+              {
+                defaultMessage: 'All dependencies',
+              }
+            )}
+            options={CONNECTION_FILTER_OPTIONS}
+            selected={connectionFilter}
+            onChange={setConnectionFilter}
+            dataTestSubj="apmServiceMapEditorConnectionFilter"
+          />
+
+          <FilterComboBox<AlertStatus>
+            label={i18n.translate('xpack.apm.serviceMapEditor.alertStatusFilterLabel', {
+              defaultMessage: 'Alert status',
+            })}
+            placeholder={i18n.translate('xpack.apm.serviceMapEditor.alertStatusFilterPlaceholder', {
+              defaultMessage: 'All alert statuses',
+            })}
+            options={ALERT_STATUS_OPTIONS}
+            selected={alertStatusFilter}
+            onChange={setAlertStatusFilter}
+            dataTestSubj="apmServiceMapEditorAlertStatusFilter"
+          />
+
+          <FilterComboBox<SloStatus>
+            label={i18n.translate('xpack.apm.serviceMapEditor.sloStatusFilterLabel', {
+              defaultMessage: 'SLO status',
+            })}
+            placeholder={i18n.translate('xpack.apm.serviceMapEditor.sloStatusFilterPlaceholder', {
+              defaultMessage: 'All SLO statuses',
+            })}
+            options={SLO_STATUS_OPTIONS}
+            selected={sloStatusFilter}
+            onChange={setSloStatusFilter}
+            dataTestSubj="apmServiceMapEditorSloStatusFilter"
+          />
+
+          <FilterComboBox<ML_ANOMALY_SEVERITY>
+            label={i18n.translate('xpack.apm.serviceMapEditor.anomalySeverityFilterLabel', {
+              defaultMessage: 'Anomaly severity',
+            })}
+            placeholder={i18n.translate(
+              'xpack.apm.serviceMapEditor.anomalySeverityFilterPlaceholder',
+              {
+                defaultMessage: 'All severities',
+              }
+            )}
+            options={ANOMALY_SEVERITY_OPTIONS}
+            selected={anomalySeverityFilter}
+            onChange={setAnomalySeverityFilter}
+            dataTestSubj="apmServiceMapEditorAnomalySeverityFilter"
+          />
+
+          <EuiHorizontalRule margin="m" />
+
+          <EuiText size="xs">
+            <h3>
+              {i18n.translate('xpack.apm.serviceMapEditor.presentationHeading', {
+                defaultMessage: 'Presentation',
+              })}
+            </h3>
+          </EuiText>
+
+          <EuiFormRow
+            label={i18n.translate('xpack.apm.serviceMapEditor.layoutLabel', {
+              defaultMessage: 'Layout',
+            })}
+            fullWidth
+          >
+            <EuiButtonGroup
+              isFullWidth
+              legend={i18n.translate('xpack.apm.serviceMapEditor.layoutLegend', {
+                defaultMessage: 'Map layout orientation',
+              })}
+              buttonSize="compressed"
+              options={orientationOptions}
+              idSelected={`${orientationIdPrefix}${mapOrientation}`}
+              onChange={(optionId) => {
+                const suffix = optionId.slice(orientationIdPrefix.length);
+                if (suffix === 'horizontal' || suffix === 'vertical') {
+                  setMapOrientation(suffix);
+                }
+              }}
+              data-test-subj="apmServiceMapEditorLayoutOrientationButtonGroup"
+            />
+          </EuiFormRow>
+
+          <EuiHorizontalRule margin="m" />
 
           <EuiFormRow
             helpText={i18n.translate('xpack.apm.serviceMapEditor.syncFiltersHelpText', {

--- a/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
+++ b/x-pack/solutions/observability/plugins/apm/public/embeddable/service_map/service_map_embeddable_factory.tsx
@@ -226,10 +226,19 @@ export const getServiceMapEmbeddableFactory = (deps: EmbeddableDeps) => {
                       }
                       customStateManager.api.setKuery(newState.kuery);
                       customStateManager.api.setServiceName(newState.service_name);
-                      // map_orientation is managed via the in-panel options toggle, not the
-                      // editor flyout; leave the persisted value untouched.
+                      if (newState.map_orientation !== undefined) {
+                        customStateManager.api.setMapOrientation(newState.map_orientation);
+                      }
                       customStateManager.api.setSyncWithDashboardFilters(
                         newState.sync_with_dashboard_filters
+                      );
+                      // View filters live in the flyout now (the in-panel embeddable is a minimal
+                      // preview), so push them through on save.
+                      customStateManager.api.setConnectionFilter(newState.connection_filter);
+                      customStateManager.api.setAlertStatusFilter(newState.alert_status_filter);
+                      customStateManager.api.setSloStatusFilter(newState.slo_status_filter);
+                      customStateManager.api.setAnomalySeverityFilter(
+                        newState.anomaly_severity_filter
                       );
                       closeFlyout();
                     }}


### PR DESCRIPTION
## Preview: 

<img width="1499" height="858" alt="image" src="https://github.com/user-attachments/assets/35b897d0-73c1-46f7-aa5a-703f05315e1a" />

<img width="1759" height="967" alt="image" src="https://github.com/user-attachments/assets/39bf4950-f92a-4c40-a927-0bc5e41f8f13" />

https://github.com/user-attachments/assets/6d8d7ef7-760b-41e8-b1f6-a4273fbfa4fb


## Summary

Design-review refinements for the **service map → dashboard** creation/edit workflow, stacked on top of the PoC branch so this diff contains **only the design changes** (easy to share with product).

> [!NOTE]
> This PR is based on `271275-apm-poc-service-map-dashboard-creationedit-workflow` (the PoC branch), not `main`, so the diff shows just the latest design feedback round.

## What changed

- **"Copy to dashboard" → Share menu on the left controls.** The action moved out of a top-right `...` menu into a `share`-icon button grouped with the other service map controls on the left. Clicking it opens a small menu with a single **Copy to dashboard** item (the APM map isn't a Lens viz, so its controls stay together).
- **The dashboard embeddable is now a minimal "preview".** The in-panel options (filters, find-in-page search, and layout orientation) are no longer shown on the dashboard panel — just the map with zoom controls + legend.
- **Filters + layout moved to the edit flyout.** The edit flyout now configures the view filters (Dependencies, Alert status, SLO status, Anomaly severity) and the **Presentation → Layout** (Horizontal/Vertical) orientation, persisted on save.
- **Removed the "Find a service" field from the flyout** (no real value in the panel config).
- The full in-app APM service map is **unchanged** — search, filters, and the inline layout control still live in its options panel.

## Validation

- `type_check` (apm), `eslint`, and `i18n_check` all pass.

## References

- Design feedback: elastic/observability-dev#5458 (comment)

> Draft for product/design review — not intended to merge into the PoC branch as-is.

Made with [Cursor](https://cursor.com)




