### PR TITLE
[APM] Migrate agent_configuration route params to zod (io-ts -> zod migration, part 8)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/agent_configuration_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/agent_configuration_params.test.ts
@@ -1,0 +1,96 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { deleteAgentConfigurationRoute } from './delete_configuration';
+import { agentConfigurationAgentNameRoute } from './get_agent_name';
+import { getSingleAgentConfigurationRoute } from './get_single_configuration';
+import { listAgentConfigurationEnvironmentsRoute } from './list_environments';
+import { searchAgentConfigurationRoute } from './search_configuration';
+
+describe('deleteAgentConfigurationRoute params', () => {
+  it('accepts a partial service', () => {
+    const result = deleteAgentConfigurationRoute.params!.safeParse({
+      body: { service: { name: 'opbeans-java' } },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an empty service', () => {
+    expectParseSuccess(deleteAgentConfigurationRoute.params!.safeParse({ body: { service: {} } }));
+  });
+});
+
+describe('agentConfigurationAgentNameRoute params', () => {
+  it('accepts a serviceName', () => {
+    const result = agentConfigurationAgentNameRoute.params!.safeParse({
+      query: { serviceName: 'opbeans-java' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    expectParseError(agentConfigurationAgentNameRoute.params!.safeParse({ query: {} }));
+  });
+});
+
+describe('getSingleAgentConfigurationRoute params', () => {
+  it('allows an entirely missing query', () => {
+    expectParseSuccess(getSingleAgentConfigurationRoute.params!.safeParse({}));
+  });
+
+  it('accepts a partial service query', () => {
+    const result = getSingleAgentConfigurationRoute.params!.safeParse({
+      query: { name: 'opbeans-java', environment: 'production' },
+    });
+
+    expectParseSuccess(result);
+  });
+});
+
+describe('listAgentConfigurationEnvironmentsRoute params', () => {
+  it('allows an entirely missing query', () => {
+    expectParseSuccess(listAgentConfigurationEnvironmentsRoute.params!.safeParse({}));
+  });
+
+  it('accepts an optional serviceName', () => {
+    const result = listAgentConfigurationEnvironmentsRoute.params!.safeParse({
+      query: { serviceName: 'opbeans-java' },
+    });
+
+    expectParseSuccess(result);
+  });
+});
+
+describe('searchAgentConfigurationRoute params', () => {
+  it('accepts a body with just a service', () => {
+    const result = searchAgentConfigurationRoute.params!.safeParse({
+      body: { service: { name: 'opbeans-java' } },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts optional etag/mark_as_applied_by_agent/error', () => {
+    const result = searchAgentConfigurationRoute.params!.safeParse({
+      body: {
+        service: { name: 'opbeans-java' },
+        etag: 'abc',
+        mark_as_applied_by_agent: true,
+        error: 'boom',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing service', () => {
+    expectParseError(searchAgentConfigurationRoute.params!.safeParse({ body: {} }));
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/delete_configuration.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/delete_configuration.ts
@@ -4,8 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { serviceRt } from '@kbn/apm-common';
+import { z } from '@kbn/zod/v4';
+import { serviceSchema } from '@kbn/apm-common';
 import { defineRoute } from '../types';
 
 export interface DeleteAgentConfigurationResponse {
@@ -14,9 +14,9 @@ export interface DeleteAgentConfigurationResponse {
 
 export const deleteAgentConfigurationRoute = defineRoute<DeleteAgentConfigurationResponse>()({
   endpoint: 'DELETE /api/apm/settings/agent-configuration 2023-10-31',
-  params: t.type({
-    body: t.type({
-      service: serviceRt,
+  params: z.object({
+    body: z.object({
+      service: serviceSchema,
     }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/get_agent_name.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/get_agent_name.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
 
 export interface AgentConfigurationAgentNameResponse {
@@ -13,7 +13,7 @@ export interface AgentConfigurationAgentNameResponse {
 
 export const agentConfigurationAgentNameRoute = defineRoute<AgentConfigurationAgentNameResponse>()({
   endpoint: 'GET /api/apm/settings/agent-configuration/agent_name 2023-10-31',
-  params: t.type({
-    query: t.type({ serviceName: t.string }),
+  params: z.object({
+    query: z.object({ serviceName: z.string() }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/get_single_configuration.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/get_single_configuration.ts
@@ -4,16 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { AgentConfiguration } from '@kbn/apm-common';
-import { serviceRt } from '@kbn/apm-common';
+import { serviceSchema } from '@kbn/apm-common';
 import { defineRoute } from '../types';
 
 export type GetSingleAgentConfigurationResponse = AgentConfiguration;
 
 export const getSingleAgentConfigurationRoute = defineRoute<GetSingleAgentConfigurationResponse>()({
   endpoint: 'GET /api/apm/settings/agent-configuration/view 2023-10-31',
-  params: t.partial({
-    query: serviceRt,
+  params: z.object({
+    query: serviceSchema.optional(),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/list_environments.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/list_environments.ts
@@ -4,7 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
 
 export type AgentConfigurationEnvironmentsResponse = Array<{
@@ -19,7 +19,7 @@ export interface ListAgentConfigurationEnvironmentsResponse {
 export const listAgentConfigurationEnvironmentsRoute =
   defineRoute<ListAgentConfigurationEnvironmentsResponse>()({
     endpoint: 'GET /api/apm/settings/agent-configuration/environments 2023-10-31',
-    params: t.partial({
-      query: t.partial({ serviceName: t.string }),
+    params: z.object({
+      query: z.object({ serviceName: z.string().optional() }).optional(),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/search_configuration.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/search_configuration.ts
@@ -4,18 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { SearchHit } from '@kbn/es-types';
 import type { AgentConfiguration } from '@kbn/apm-common';
-import { serviceRt } from '@kbn/apm-common';
+import { serviceSchema } from '@kbn/apm-common';
 import { defineRoute } from '../types';
 
-const searchParamsRt = t.intersection([
-  t.type({ service: serviceRt }),
-  t.partial({ etag: t.string, mark_as_applied_by_agent: t.boolean, error: t.string }),
-]);
+const searchParamsSchema = z.object({ service: serviceSchema }).extend({
+  etag: z.string().optional(),
+  mark_as_applied_by_agent: z.boolean().optional(),
+  error: z.string().optional(),
+});
 
-export type AgentConfigSearchParams = t.TypeOf<typeof searchParamsRt>;
+export type AgentConfigSearchParams = z.infer<typeof searchParamsSchema>;
 
 export type SearchAgentConfigurationResponse = SearchHit<
   AgentConfiguration,
@@ -25,7 +26,7 @@ export type SearchAgentConfigurationResponse = SearchHit<
 
 export const searchAgentConfigurationRoute = defineRoute<SearchAgentConfigurationResponse>()({
   endpoint: 'POST /api/apm/settings/agent-configuration/search 2023-10-31',
-  params: t.type({
-    body: searchParamsRt,
+  params: z.object({
+    body: searchParamsSchema,
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-common/index.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/index.ts
@@ -35,6 +35,7 @@ export {
 // Runtime types
 export {
   serviceRt,
+  serviceSchema,
   settingsRt,
   agentConfigurationIntakeRt,
 } from './src/agent_configuration/runtime_types/agent_configuration_intake_rt';

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/agent_configuration_intake_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/agent_configuration_intake_rt.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { settingDefinitions } from '../setting_definitions';
 import type { SettingValidation } from '../setting_definitions/types';
 
@@ -21,6 +22,17 @@ const knownSettings = settingDefinitions.reduce<Record<string, SettingValidation
 export const serviceRt = t.partial({
   name: t.string,
   environment: t.string,
+});
+
+/**
+ * zod equivalent, additive (see `default_api_types.ts` in `@kbn/apm-api-shared`
+ * for why - elastic/kibana#243355). `settingsRt`/`agentConfigurationIntakeRt`
+ * are not ported here yet: they pull in the whole per-setting validation
+ * subsystem in `../setting_definitions`, which needs its own migration pass.
+ */
+export const serviceSchema = z.object({
+  name: z.string().optional(),
+  environment: z.string().optional(),
 });
 
 export const settingsRt = t.intersection([t.record(t.string, t.string), t.partial(knownSettings)]);

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/service_schema.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/service_schema.test.ts
@@ -1,0 +1,28 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { serviceSchema } from './agent_configuration_intake_rt';
+
+describe('serviceSchema', () => {
+  it('accepts an empty object', () => {
+    expectParseSuccess(serviceSchema.safeParse({}));
+  });
+
+  it('accepts a partial service', () => {
+    const result = serviceSchema.safeParse({ name: 'opbeans-java' });
+
+    expectParseSuccess(result);
+    expect(result.data).toEqual({ name: 'opbeans-java' });
+  });
+
+  it('accepts both name and environment', () => {
+    const result = serviceSchema.safeParse({ name: 'opbeans-java', environment: 'production' });
+
+    expectParseSuccess(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-common/tsconfig.json
+++ b/x-pack/platform/packages/shared/kbn-apm-common/tsconfig.json
@@ -9,5 +9,7 @@
   "kbn_references": [
     "@kbn/i18n",
     "@kbn/elastic-agent-utils",
+    "@kbn/zod",
+    "@kbn/zod-helpers",
   ]
 }


### PR DESCRIPTION
## Summary

Part of the `io-ts` -> `@kbn/zod` migration tracked in elastic/kibana#243355.

Stacked on elastic/kibana#277145 (still open) — this PR is opened against
that branch on the fork so the diff stays scoped to this batch. Once
#277145 merges upstream, this branch will be rebased and the PR reopened
against `elastic/kibana:main`.

Migrates 5 of the 6 `agent_configuration` route files to zod params, and
adds an additive `serviceSchema` export to `@kbn/apm-common` alongside the
untouched `serviceRt` (same additive pattern used for the other shared
codecs — existing io-ts consumers are untouched).

## Changes

- `kbn-apm-api-shared/src/routes/agent_configuration/`:
  - `delete_configuration.ts`
  - `get_agent_name.ts`
  - `get_single_configuration.ts`
  - `list_environments.ts`
  - `search_configuration.ts`
- `kbn-apm-common`: additive `serviceSchema` export (zod) next to `serviceRt` (io-ts), plus `@kbn/zod`/`@kbn/zod-helpers` added to `tsconfig.json`.

`create_or_update_configuration.ts` is **deliberately left on io-ts**: it
depends on `agentConfigurationIntakeRt` -> `settingsRt`, which pulls in the
whole per-setting validator subsystem in `setting_definitions/` (java,
edot_sdk, general, mobile settings). That's a much larger migration and
deserves its own dedicated PR.

## Test plan

- [x] Added `agent_configuration_params.test.ts` covering safeParse success/error cases for all 5 converted routes.
- [x] Added `service_schema.test.ts` covering the new `serviceSchema`.
- [x] `kbn-apm-api-shared` full jest suite passes (97/97, including new tests).
- [x] `kbn-apm-common` new tests pass (3/3).
- [x] Existing plugin-side tests for this route group still pass: `queries.test.ts`, `handle_agent_configuration_search.test.ts` (15/15).
- [x] Type-check clean via the oblt CLI for `kbn-apm-common`, `kbn-apm-api-shared`.
- [x] `node scripts/lint_ts_projects.js` clean.
- [ ] Existing FTR spec `agent_configuration.spec.ts` not re-run in this PR — relying on the unit/plugin test coverage above plus manual verification via Kibana Dev Tools Console.