### PR TITLE
[APM] Migrate 8 more route groups to zod (io-ts -> zod migration, part 9)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/index.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/index.ts
@@ -47,7 +47,7 @@ export type * from './src/routes/fleet';
 export type * from './src/routes/storage_explorer';
 export type * from './src/routes/source_maps';
 export type * from './src/routes/agent_configuration';
-export { sourceMapRt } from './src/routes/source_maps';
+export { sourceMapSchema } from './src/routes/source_maps';
 export { filterOptionsRt, payloadRt } from './src/routes/custom_links';
 export {
   rangeRt,

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/correlations_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/correlations_params.test.ts
@@ -1,0 +1,217 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { fieldCandidatesTransactionsRoute } from './field_candidates_transactions';
+import { fieldValuePairsTransactionsRoute } from './field_value_pairs_transactions';
+import { fieldValueStatsTransactionsRoute } from './field_value_stats_transactions';
+import { pValuesTransactionsRoute } from './p_values_transactions';
+import { significantCorrelationsTransactionsRoute } from './significant_correlations_transactions';
+import { unifiedCorrelationsRoute } from './unified_correlations';
+
+describe('fieldCandidatesTransactionsRoute params', () => {
+  it('accepts a query with only the required fields', () => {
+    const result = fieldCandidatesTransactionsRoute.params!.safeParse({
+      query: { environment: 'production', kuery: '', start: '2021-01-01', end: '2021-01-02' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing the required range', () => {
+    expectParseError(
+      fieldCandidatesTransactionsRoute.params!.safeParse({
+        query: { environment: 'production', kuery: '' },
+      })
+    );
+  });
+});
+
+describe('fieldValuePairsTransactionsRoute params', () => {
+  it('accepts a body with only the required fields', () => {
+    const result = fieldValuePairsTransactionsRoute.params!.safeParse({
+      body: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        fieldCandidates: ['field1', 'field2'],
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a body missing the required fieldCandidates', () => {
+    expectParseError(
+      fieldValuePairsTransactionsRoute.params!.safeParse({
+        body: { environment: 'production', kuery: '', start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+});
+
+describe('fieldValueStatsTransactionsRoute params', () => {
+  it('accepts a query with only the required fields', () => {
+    const result = fieldValueStatsTransactionsRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        fieldName: 'foo',
+        fieldValue: 'bar',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing the required fieldName/fieldValue', () => {
+    expectParseError(
+      fieldValueStatsTransactionsRoute.params!.safeParse({
+        query: { environment: 'production', kuery: '', start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+});
+
+describe('pValuesTransactionsRoute params', () => {
+  it('accepts a body with only the required fields', () => {
+    const result = pValuesTransactionsRoute.params!.safeParse({
+      body: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        fieldCandidates: ['field1'],
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('coerces optional durationMin/durationMax to numbers', () => {
+    const result = pValuesTransactionsRoute.params!.safeParse({
+      body: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        fieldCandidates: ['field1'],
+        durationMin: '10',
+        durationMax: '20',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a body missing the required fieldCandidates', () => {
+    expectParseError(
+      pValuesTransactionsRoute.params!.safeParse({
+        body: { environment: 'production', kuery: '', start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+});
+
+describe('significantCorrelationsTransactionsRoute params', () => {
+  it('accepts a body with only the required fields', () => {
+    const result = significantCorrelationsTransactionsRoute.params!.safeParse({
+      body: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        fieldValuePairs: [{ fieldName: 'foo', fieldValue: 'bar' }],
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('coerces a numeric fieldValue', () => {
+    const result = significantCorrelationsTransactionsRoute.params!.safeParse({
+      body: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        fieldValuePairs: [{ fieldName: 'foo', fieldValue: '42' }],
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a body missing the required fieldValuePairs', () => {
+    expectParseError(
+      significantCorrelationsTransactionsRoute.params!.safeParse({
+        body: { environment: 'production', kuery: '', start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+});
+
+describe('unifiedCorrelationsRoute params', () => {
+  it('accepts a body with only the required fields', () => {
+    const result = unifiedCorrelationsRoute.params!.safeParse({
+      body: {
+        entityType: 'transaction',
+        metric: 'latency',
+        start: '2021-01-01',
+        end: '2021-01-02',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts optional fields, coercing durationMin/durationMax/percentileThreshold/includeHistogram', () => {
+    const result = unifiedCorrelationsRoute.params!.safeParse({
+      body: {
+        entityType: 'exit_span',
+        metric: 'throughput',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        environment: 'production',
+        serviceName: 'opbeans-java',
+        durationMin: '10',
+        durationMax: '20',
+        percentileThreshold: '95',
+        includeHistogram: 'true',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an invalid entityType', () => {
+    expectParseError(
+      unifiedCorrelationsRoute.params!.safeParse({
+        body: { entityType: 'invalid', metric: 'latency', start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+
+  it('rejects a missing metric', () => {
+    expectParseError(
+      unifiedCorrelationsRoute.params!.safeParse({
+        body: { entityType: 'transaction', start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+
+  it('rejects a body missing the required range', () => {
+    expectParseError(
+      unifiedCorrelationsRoute.params!.safeParse({
+        body: { entityType: 'transaction', metric: 'latency' },
+      })
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_candidates_transactions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_candidates_transactions.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface DurationFieldCandidatesResponse {
   fieldCandidates: string[];
@@ -15,16 +15,15 @@ export interface DurationFieldCandidatesResponse {
 
 export const fieldCandidatesTransactionsRoute = defineRoute<DurationFieldCandidatesResponse>()({
   endpoint: 'GET /internal/apm/correlations/field_candidates/transactions',
-  params: t.type({
-    query: t.intersection([
-      t.partial({
-        serviceName: t.string,
-        transactionName: t.string,
-        transactionType: t.string,
-      }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-    ]),
+  params: z.object({
+    query: z
+      .object({
+        serviceName: z.string().optional(),
+        transactionName: z.string().optional(),
+        transactionType: z.string().optional(),
+      })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_value_pairs_transactions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_value_pairs_transactions.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { FieldValuePair } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface FieldValuePairsResponse {
   fieldValuePairs: FieldValuePair[];
@@ -17,19 +17,18 @@ export interface FieldValuePairsResponse {
 
 export const fieldValuePairsTransactionsRoute = defineRoute<FieldValuePairsResponse>()({
   endpoint: 'POST /internal/apm/correlations/field_value_pairs/transactions',
-  params: t.type({
-    body: t.intersection([
-      t.partial({
-        serviceName: t.string,
-        transactionName: t.string,
-        transactionType: t.string,
+  params: z.object({
+    body: z
+      .object({
+        serviceName: z.string().optional(),
+        transactionName: z.string().optional(),
+        transactionType: z.string().optional(),
+      })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .extend({
+        fieldCandidates: z.array(z.string()),
       }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      t.type({
-        fieldCandidates: t.array(t.string),
-      }),
-    ]),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_value_stats_transactions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/field_value_stats_transactions.ts
@@ -4,31 +4,30 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { TopValuesStats } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type FieldValueStatsTransactionsResponse = TopValuesStats;
 
 export const fieldValueStatsTransactionsRoute = defineRoute<FieldValueStatsTransactionsResponse>()({
   endpoint: 'GET /internal/apm/correlations/field_value_stats/transactions',
-  params: t.type({
-    query: t.intersection([
-      t.partial({
-        serviceName: t.string,
-        transactionName: t.string,
-        transactionType: t.string,
-        samplerShardSize: t.string,
+  params: z.object({
+    query: z
+      .object({
+        serviceName: z.string().optional(),
+        transactionName: z.string().optional(),
+        transactionType: z.string().optional(),
+        samplerShardSize: z.string().optional(),
+      })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .extend({
+        fieldName: z.string(),
+        fieldValue: z.union([z.string(), z.number()]),
       }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      t.type({
-        fieldName: t.string,
-        fieldValue: t.union([t.string, t.number]),
-      }),
-    ]),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/p_values_transactions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/p_values_transactions.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { FailedTransactionsCorrelation } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface PValuesResponse {
   failedTransactionsCorrelations: FailedTransactionsCorrelation[];
@@ -19,21 +18,20 @@ export interface PValuesResponse {
 
 export const pValuesTransactionsRoute = defineRoute<PValuesResponse>()({
   endpoint: 'POST /internal/apm/correlations/p_values/transactions',
-  params: t.type({
-    body: t.intersection([
-      t.partial({
-        serviceName: t.string,
-        transactionName: t.string,
-        transactionType: t.string,
-        durationMin: toNumberRt,
-        durationMax: toNumberRt,
+  params: z.object({
+    body: z
+      .object({
+        serviceName: z.string().optional(),
+        transactionName: z.string().optional(),
+        transactionType: z.string().optional(),
+        durationMin: z.coerce.number().optional(),
+        durationMax: z.coerce.number().optional(),
+      })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .extend({
+        fieldCandidates: z.array(z.string()),
       }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      t.type({
-        fieldCandidates: t.array(t.string),
-      }),
-    ]),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/significant_correlations_transactions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/significant_correlations_transactions.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { LatencyCorrelation } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface SignificantCorrelationsResponse {
   latencyCorrelations: LatencyCorrelation[];
@@ -21,26 +20,25 @@ export interface SignificantCorrelationsResponse {
 export const significantCorrelationsTransactionsRoute =
   defineRoute<SignificantCorrelationsResponse>()({
     endpoint: 'POST /internal/apm/correlations/significant_correlations/transactions',
-    params: t.type({
-      body: t.intersection([
-        t.partial({
-          serviceName: t.string,
-          transactionName: t.string,
-          transactionType: t.string,
-          durationMin: toNumberRt,
-          durationMax: toNumberRt,
-        }),
-        environmentRt,
-        kueryRt,
-        rangeRt,
-        t.type({
-          fieldValuePairs: t.array(
-            t.type({
-              fieldName: t.string,
-              fieldValue: t.union([t.string, toNumberRt]),
+    params: z.object({
+      body: z
+        .object({
+          serviceName: z.string().optional(),
+          transactionName: z.string().optional(),
+          transactionType: z.string().optional(),
+          durationMin: z.coerce.number().optional(),
+          durationMax: z.coerce.number().optional(),
+        })
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema)
+        .extend({
+          fieldValuePairs: z.array(
+            z.object({
+              fieldName: z.string(),
+              fieldValue: z.union([z.string(), z.coerce.number()]),
             })
           ),
         }),
-      ]),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/types.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/types.ts
@@ -4,13 +4,8 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 
-export const entityTypeRt = t.union([t.literal('transaction'), t.literal('exit_span')]);
+export const entityTypeSchema = z.enum(['transaction', 'exit_span']);
 
-export const metricRt = t.union([
-  t.literal('latency'),
-  t.literal('failure_rate'),
-  t.literal('throughput'),
-  t.literal('infra_metrics'),
-]);
+export const metricSchema = z.enum(['latency', 'failure_rate', 'throughput', 'infra_metrics']);

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/unified_correlations.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/correlations/unified_correlations.ts
@@ -4,36 +4,35 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toBooleanRt, toNumberRt } from '@kbn/io-ts-utils';
-import { environmentRt, type CorrelationsResponse } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
+import { environmentSchema, type CorrelationsResponse } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
-import { entityTypeRt, metricRt } from './types';
+import { rangeSchema } from '../../default_api_types';
+import { entityTypeSchema, metricSchema } from './types';
 
 export type UnifiedCorrelationsRouteResponse = CorrelationsResponse;
 
 export const unifiedCorrelationsRoute = defineRoute<UnifiedCorrelationsRouteResponse>()({
   endpoint: 'POST /internal/apm/correlations',
-  params: t.type({
-    body: t.intersection([
-      t.type({
-        entityType: entityTypeRt,
-        metric: metricRt,
-      }),
-      t.partial({
-        serviceName: t.string,
-        transactionName: t.string,
-        transactionType: t.string,
-        fieldCandidates: t.array(t.string),
-        durationMin: toNumberRt,
-        durationMax: toNumberRt,
-        percentileThreshold: toNumberRt,
-        includeHistogram: toBooleanRt,
-        kuery: t.string,
-      }),
-      t.partial(environmentRt.props),
-      rangeRt,
-    ]),
+  params: z.object({
+    body: z
+      .object({
+        entityType: entityTypeSchema,
+        metric: metricSchema,
+      })
+      .extend({
+        serviceName: z.string().optional(),
+        transactionName: z.string().optional(),
+        transactionType: z.string().optional(),
+        fieldCandidates: z.array(z.string()).optional(),
+        durationMin: z.coerce.number().optional(),
+        durationMax: z.coerce.number().optional(),
+        percentileThreshold: z.coerce.number().optional(),
+        includeHistogram: BooleanFromString.optional(),
+        kuery: z.string().optional(),
+      })
+      .merge(environmentSchema.partial())
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_distribution.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_distribution.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface ErrorDistributionResponse {
   currentPeriod: Array<{ x: number; y: number }>;
@@ -19,18 +18,17 @@ export interface ErrorDistributionResponse {
 
 export const errorDistributionRoute = defineRoute<ErrorDistributionResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/errors/distribution',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.partial({
-        groupId: t.string,
-        transactionName: t.string,
-        bucketSizeInSeconds: toNumberRt,
-      }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      offsetRt,
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({
+        groupId: z.string().optional(),
+        transactionName: z.string().optional(),
+        bucketSizeInSeconds: z.coerce.number().optional(),
+      })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_group_samples.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_group_samples.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface ErrorGroupSampleIdsResponse {
   errorSampleIds: string[];
@@ -16,8 +16,8 @@ export interface ErrorGroupSampleIdsResponse {
 
 export const errorGroupSamplesRoute = defineRoute<ErrorGroupSampleIdsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/errors/{groupId}/samples',
-  params: t.type({
-    path: t.type({ serviceName: t.string, groupId: t.string }),
-    query: t.intersection([environmentRt, kueryRt, rangeRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string(), groupId: z.string() }),
+    query: environmentSchema.merge(kuerySchema).merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_groups_detailed_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_groups_detailed_statistics.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface ErrorGroupDetailedStat {
   groupId: string;
@@ -21,17 +20,29 @@ export interface ErrorGroupPeriodsResponse {
   previousPeriod: Record<string, ErrorGroupDetailedStat>;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value as an array of strings.
+const groupIdsSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const errorsDetailedStatisticsRoute = defineRoute<ErrorGroupPeriodsResponse>()({
   endpoint: 'POST /internal/apm/services/{serviceName}/errors/groups/detailed_statistics',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      offsetRt,
-      t.type({ numBuckets: toNumberRt }),
-    ]),
-    body: t.type({ groupIds: jsonRt.pipe(t.array(t.string)) }),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: environmentSchema
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema)
+      .merge(z.object({ numBuckets: z.coerce.number() })),
+    body: z.object({ groupIds: groupIdsSchema }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_groups_main_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_groups_main_statistics.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface ErrorGroupMainStatisticsResponse {
   errorGroups: Array<{
@@ -26,18 +25,17 @@ export interface ErrorGroupMainStatisticsResponse {
 
 export const errorsMainStatisticsRoute = defineRoute<ErrorGroupMainStatisticsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/errors/groups/main_statistics',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.partial({
-        sortField: t.string,
-        sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
-        searchQuery: t.string,
-      }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({
+        sortField: z.string().optional(),
+        sortDirection: z.union([z.literal('asc'), z.literal('desc')]).optional(),
+        searchQuery: z.string().optional(),
+      })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });
 
@@ -45,17 +43,16 @@ export const errorsMainStatisticsByTransactionNameRoute =
   defineRoute<ErrorGroupMainStatisticsResponse>()({
     endpoint:
       'GET /internal/apm/services/{serviceName}/errors/groups/main_statistics_by_transaction_name',
-    params: t.type({
-      path: t.type({ serviceName: t.string }),
-      query: t.intersection([
-        t.type({
-          transactionType: t.string,
-          transactionName: t.string,
-          maxNumberOfErrorGroups: toNumberRt,
-        }),
-        environmentRt,
-        kueryRt,
-        rangeRt,
-      ]),
+    params: z.object({
+      path: z.object({ serviceName: z.string() }),
+      query: z
+        .object({
+          transactionType: z.string(),
+          transactionName: z.string(),
+          maxNumberOfErrorGroups: z.coerce.number(),
+        })
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_sample_details.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/error_sample_details.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { Transaction, APMError } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface ErrorSampleDetailsResponse {
   transaction: Transaction | undefined;
@@ -26,8 +26,8 @@ export interface ErrorSampleDetailsResponse {
 
 export const errorSampleDetailsRoute = defineRoute<ErrorSampleDetailsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/errors/{groupId}/error/{errorId}',
-  params: t.type({
-    path: t.type({ serviceName: t.string, groupId: t.string, errorId: t.string }),
-    query: t.intersection([environmentRt, kueryRt, rangeRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string(), groupId: z.string(), errorId: z.string() }),
+    query: environmentSchema.merge(kuerySchema).merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/errors_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/errors_params.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { errorDistributionRoute } from './error_distribution';
+import { errorGroupSamplesRoute } from './error_group_samples';
+import { errorsDetailedStatisticsRoute } from './error_groups_detailed_statistics';
+import {
+  errorsMainStatisticsRoute,
+  errorsMainStatisticsByTransactionNameRoute,
+} from './error_groups_main_statistics';
+import { errorSampleDetailsRoute } from './error_sample_details';
+import { topErroneousTransactionsRoute } from './top_erroneous_transactions';
+
+describe('errorDistributionRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = errorDistributionRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        bucketSizeInSeconds: '60',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    expectParseError(
+      errorDistributionRoute.params!.safeParse({
+        path: {},
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});
+
+describe('errorGroupSamplesRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = errorGroupSamplesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java', groupId: 'abc123' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing groupId', () => {
+    expectParseError(
+      errorGroupSamplesRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});
+
+describe('errorsDetailedStatisticsRoute params', () => {
+  it('accepts a valid path, query and body', () => {
+    const result = errorsDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { groupIds: JSON.stringify(['abc123', 'def456']) },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.body.groupIds).toEqual(['abc123', 'def456']);
+    }
+  });
+
+  it('rejects a body with invalid JSON groupIds', () => {
+    expectParseError(
+      errorsDetailedStatisticsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          numBuckets: '20',
+        },
+        body: { groupIds: 'not-json' },
+      })
+    );
+  });
+});
+
+describe('errorsMainStatisticsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = errorsMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        sortField: 'occurrences',
+        sortDirection: 'desc',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an invalid sortDirection', () => {
+    expectParseError(
+      errorsMainStatisticsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          sortDirection: 'sideways',
+        },
+      })
+    );
+  });
+});
+
+describe('errorsMainStatisticsByTransactionNameRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = errorsMainStatisticsByTransactionNameRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        transactionType: 'request',
+        transactionName: 'GET /api',
+        maxNumberOfErrorGroups: '5',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing transactionName', () => {
+    expectParseError(
+      errorsMainStatisticsByTransactionNameRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          transactionType: 'request',
+          maxNumberOfErrorGroups: '5',
+        },
+      })
+    );
+  });
+});
+
+describe('errorSampleDetailsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = errorSampleDetailsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java', groupId: 'abc123', errorId: 'err1' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing errorId', () => {
+    expectParseError(
+      errorSampleDetailsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java', groupId: 'abc123' },
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});
+
+describe('topErroneousTransactionsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = topErroneousTransactionsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java', groupId: 'abc123' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        numBuckets: '20',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing numBuckets', () => {
+    expectParseError(
+      topErroneousTransactionsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java', groupId: 'abc123' },
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/top_erroneous_transactions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/errors/top_erroneous_transactions.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface TopErroneousTransactionsResponse {
   topErroneousTransactions: Array<{
@@ -22,14 +21,12 @@ export interface TopErroneousTransactionsResponse {
 
 export const topErroneousTransactionsRoute = defineRoute<TopErroneousTransactionsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/errors/{groupId}/top_erroneous_transactions',
-  params: t.type({
-    path: t.type({ serviceName: t.string, groupId: t.string }),
-    query: t.intersection([
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      offsetRt,
-      t.type({ numBuckets: toNumberRt }),
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string(), groupId: z.string() }),
+    query: environmentSchema
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema)
+      .merge(z.object({ numBuckets: z.coerce.number() })),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/metrics_charts.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/metrics_charts.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { Coordinate, YUnit, ChartType } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface FetchAndTransformMetrics {
   title: string;
@@ -32,14 +32,13 @@ export interface MetricsChartsResponse {
 
 export const metricsChartsRoute = defineRoute<MetricsChartsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/metrics/charts',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.type({ agentName: t.string }),
-      t.partial({ serviceNodeName: t.string }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({ agentName: z.string() })
+      .merge(z.object({ serviceNodeName: z.string() }).partial())
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/metrics_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/metrics_params.test.ts
@@ -1,0 +1,232 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { ApmDocumentType, RollupInterval } from '@kbn/apm-types';
+import { metricsChartsRoute } from './metrics_charts';
+import { serverlessActiveInstancesRoute } from './serverless_active_instances';
+import { serverlessMetricsChartsRoute } from './serverless_charts';
+import { serverlessFunctionsOverviewRoute } from './serverless_functions_overview';
+import { serverlessSummaryRoute } from './serverless_summary';
+import { serviceMetricsNodesRoute } from './service_nodes';
+
+const range = {
+  start: '2023-01-01T00:00:00.000Z',
+  end: '2023-01-02T00:00:00.000Z',
+};
+
+describe('metricsChartsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = metricsChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        agentName: 'java',
+        environment: 'production',
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an optional serviceNodeName', () => {
+    const result = metricsChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        agentName: 'java',
+        serviceNodeName: '_all',
+        environment: 'production',
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing agentName', () => {
+    const result = metricsChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('serverlessActiveInstancesRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serverlessActiveInstancesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an optional serverlessId', () => {
+    const result = serverlessActiveInstancesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        serverlessId: 'my-function',
+        ...range,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing environment', () => {
+    const result = serverlessActiveInstancesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('serverlessMetricsChartsRoute params', () => {
+  const validQuery = {
+    environment: 'production',
+    kuery: '',
+    ...range,
+    documentType: ApmDocumentType.TransactionMetric,
+    rollupInterval: RollupInterval.OneMinute,
+    bucketSizeInSeconds: '60',
+  };
+
+  it('accepts a valid path and query, coercing bucketSizeInSeconds to a number', () => {
+    const result = serverlessMetricsChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: validQuery,
+    });
+
+    expectParseSuccess(result);
+    expect(result.data.query.bucketSizeInSeconds).toBe(60);
+  });
+
+  it('rejects an invalid documentType', () => {
+    const result = serverlessMetricsChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: { ...validQuery, documentType: 'notADocumentType' },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('serverlessFunctionsOverviewRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serverlessFunctionsOverviewRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing range', () => {
+    const result = serverlessFunctionsOverviewRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        environment: 'production',
+        kuery: '',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('serverlessSummaryRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serverlessSummaryRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an optional serverlessId', () => {
+    const result = serverlessSummaryRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        serverlessId: 'my-function',
+        ...range,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing path', () => {
+    const result = serverlessSummaryRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('serviceMetricsNodesRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceMetricsNodesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        ...range,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an invalid start/end date', () => {
+    const result = serviceMetricsNodesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-node' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: 'not-a-date',
+        end: 'not-a-date',
+      },
+    });
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_active_instances.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_active_instances.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface ActiveInstanceTimeseries {
   serverlessDuration: Coordinate[];
@@ -33,8 +33,11 @@ export interface ServerlessActiveInstancesResponse {
 
 export const serverlessActiveInstancesRoute = defineRoute<ServerlessActiveInstancesResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/metrics/serverless/active_instances',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([environmentRt, kueryRt, rangeRt, t.partial({ serverlessId: t.string })]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: environmentSchema
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(z.object({ serverlessId: z.string() }).partial()),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_charts.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_charts.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import type { FetchAndTransformMetrics } from './metrics_charts';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, transactionDataSourceRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, transactionDataSourceSchema } from '../../default_api_types';
 
 export interface ServerlessMetricsChartsResponse {
   charts: FetchAndTransformMetrics[];
@@ -17,14 +16,13 @@ export interface ServerlessMetricsChartsResponse {
 
 export const serverlessMetricsChartsRoute = defineRoute<ServerlessMetricsChartsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/metrics/serverless/charts',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      t.partial({ serverlessId: t.string }),
-      t.intersection([transactionDataSourceRt, t.type({ bucketSizeInSeconds: toNumberRt })]),
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: environmentSchema
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(z.object({ serverlessId: z.string() }).partial())
+      .merge(transactionDataSourceSchema)
+      .merge(z.object({ bucketSizeInSeconds: z.coerce.number() })),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_functions_overview.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_functions_overview.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type ServerlessFunctionsOverviewResponse = Array<{
   serverlessId: string;
@@ -26,8 +26,8 @@ export interface ServerlessFunctionsOverviewRouteResponse {
 export const serverlessFunctionsOverviewRoute =
   defineRoute<ServerlessFunctionsOverviewRouteResponse>()({
     endpoint: 'GET /internal/apm/services/{serviceName}/metrics/serverless/functions_overview',
-    params: t.type({
-      path: t.type({ serviceName: t.string }),
-      query: t.intersection([environmentRt, kueryRt, rangeRt]),
+    params: z.object({
+      path: z.object({ serviceName: z.string() }),
+      query: environmentSchema.merge(kuerySchema).merge(rangeSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_summary.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/serverless_summary.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type AwsLambdaArchitecture = 'arm' | 'x86_64';
 
@@ -23,8 +23,11 @@ export interface ServerlessSummaryResponse {
 
 export const serverlessSummaryRoute = defineRoute<ServerlessSummaryResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/metrics/serverless/summary',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([environmentRt, kueryRt, rangeRt, t.partial({ serverlessId: t.string })]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: environmentSchema
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(z.object({ serverlessId: z.string() }).partial()),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/service_nodes.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/metrics/service_nodes.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type ServiceNodesResponse = Array<{
   name: string;
@@ -24,8 +24,8 @@ export interface ServiceMetricsNodesRouteResponse {
 
 export const serviceMetricsNodesRoute = defineRoute<ServiceMetricsNodesRouteResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/metrics/nodes',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([kueryRt, rangeRt, environmentRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: kuerySchema.merge(rangeSchema).merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_detailed_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_detailed_statistics.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import { type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface CrashGroupDetailedStat {
   groupId: string;
@@ -21,21 +20,35 @@ export interface MobileCrashesGroupPeriodsResponse {
   previousPeriod: Record<string, CrashGroupDetailedStat>;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value is an array of strings.
+const groupIdsJsonSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const crashDetailedStatisticsRoute = defineRoute<MobileCrashesGroupPeriodsResponse>()({
   endpoint: 'POST /internal/apm/mobile-services/{serviceName}/crashes/groups/detailed_statistics',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      offsetRt,
-      t.type({
-        numBuckets: toNumberRt,
-      }),
-    ]),
-    body: t.type({ groupIds: jsonRt.pipe(t.array(t.string)) }),
+    query: environmentSchema
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema)
+      .merge(
+        z.object({
+          numBuckets: z.coerce.number(),
+        })
+      ),
+    body: z.object({ groupIds: groupIdsJsonSchema }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_distribution.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_distribution.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface CrashDistributionResponse {
   currentPeriod: Array<{ x: number; y: number }>;
@@ -18,18 +18,17 @@ export interface CrashDistributionResponse {
 
 export const crashDistributionRoute = defineRoute<CrashDistributionResponse>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/crashes/distribution',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      t.partial({
-        groupId: t.string,
-      }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      offsetRt,
-    ]),
+    query: z
+      .object({
+        groupId: z.string().optional(),
+      })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_main_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/crash_main_statistics.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type MobileCrashGroupMainStatisticsResponse = Array<{
   groupId: string;
@@ -25,18 +25,17 @@ export interface CrashMainStatisticsRouteResponse {
 
 export const crashMainStatisticsRoute = defineRoute<CrashMainStatisticsRouteResponse>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/crashes/groups/main_statistics',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      t.partial({
-        sortField: t.string,
-        sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
-      }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-    ]),
+    query: z
+      .object({
+        sortField: z.string().optional(),
+        sortDirection: z.union([z.literal('asc'), z.literal('desc')]).optional(),
+      })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/mobile_crashes_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_crashes/mobile_crashes_params.test.ts
@@ -1,0 +1,154 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { crashDetailedStatisticsRoute } from './crash_detailed_statistics';
+import { crashDistributionRoute } from './crash_distribution';
+import { crashMainStatisticsRoute } from './crash_main_statistics';
+
+describe('crashDetailedStatisticsRoute params', () => {
+  it('accepts valid path, query and body', () => {
+    const result = crashDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { groupIds: JSON.stringify(['groupId1', 'groupId2']) },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a body with a non-JSON groupIds', () => {
+    const result = crashDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { groupIds: 'not-json' },
+    });
+
+    expectParseError(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    const result = crashDetailedStatisticsRoute.params!.safeParse({
+      path: {},
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { groupIds: JSON.stringify(['groupId1']) },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('crashDistributionRoute params', () => {
+  it('accepts a query without an optional groupId', () => {
+    const result = crashDistributionRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts a query with an optional groupId and offset', () => {
+    const result = crashDistributionRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        groupId: 'groupId1',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        offset: '1d',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    const result = crashDistributionRoute.params!.safeParse({
+      path: {},
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('crashMainStatisticsRoute params', () => {
+  it('accepts a query without optional sort fields', () => {
+    const result = crashMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts a query with sortField/sortDirection', () => {
+    const result = crashMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        sortField: 'occurrences',
+        sortDirection: 'desc',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an invalid sortDirection', () => {
+    const result = crashMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        sortDirection: 'invalid',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_error_terms.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_error_terms.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type MobileErrorTermsByFieldResponse = Array<{
   label: string;
@@ -21,18 +20,18 @@ export interface MobileErrorTermsRouteResponse {
 
 export const mobileErrorTermsRoute = defineRoute<MobileErrorTermsRouteResponse>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/error_terms',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      t.type({
-        size: toNumberRt,
-        fieldName: t.string,
-      }),
-    ]),
+    query: kuerySchema
+      .merge(rangeSchema)
+      .merge(environmentSchema)
+      .merge(
+        z.object({
+          size: z.coerce.number(),
+          fieldName: z.string(),
+        })
+      ),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_detailed_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_detailed_statistics.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import { type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface MobileErrorGroupDetailedStat {
   groupId: string;
@@ -21,21 +20,35 @@ export interface MobileErrorGroupPeriodsResponse {
   previousPeriod: Record<string, MobileErrorGroupDetailedStat>;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value is an array of strings.
+const groupIdsJsonSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const mobileErrorsDetailedStatisticsRoute = defineRoute<MobileErrorGroupPeriodsResponse>()({
   endpoint: 'POST /internal/apm/mobile-services/{serviceName}/errors/groups/detailed_statistics',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      environmentRt,
-      kueryRt,
-      rangeRt,
-      offsetRt,
-      t.type({
-        numBuckets: toNumberRt,
-      }),
-    ]),
-    body: t.type({ groupIds: jsonRt.pipe(t.array(t.string)) }),
+    query: environmentSchema
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema)
+      .merge(
+        z.object({
+          numBuckets: z.coerce.number(),
+        })
+      ),
+    body: z.object({ groupIds: groupIdsJsonSchema }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_main_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_main_statistics.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type MobileErrorGroupMainStatisticsResponse = Array<{
   groupId: string;
@@ -26,18 +26,17 @@ export interface MobileErrorsMainStatisticsRouteResponse {
 export const mobileErrorsMainStatisticsRoute =
   defineRoute<MobileErrorsMainStatisticsRouteResponse>()({
     endpoint: 'GET /internal/apm/mobile-services/{serviceName}/errors/groups/main_statistics',
-    params: t.type({
-      path: t.type({
-        serviceName: t.string,
+    params: z.object({
+      path: z.object({
+        serviceName: z.string(),
       }),
-      query: t.intersection([
-        t.partial({
-          sortField: t.string,
-          sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
-        }),
-        environmentRt,
-        kueryRt,
-        rangeRt,
-      ]),
+      query: z
+        .object({
+          sortField: z.string().optional(),
+          sortDirection: z.union([z.literal('asc'), z.literal('desc')]).optional(),
+        })
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_errors_params.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { mobileErrorTermsRoute } from './mobile_error_terms';
+import { mobileErrorsDetailedStatisticsRoute } from './mobile_errors_detailed_statistics';
+import { mobileErrorsMainStatisticsRoute } from './mobile_errors_main_statistics';
+import { mobileHttpErrorRateRoute } from './mobile_http_error_rate';
+
+describe('mobileErrorTermsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = mobileErrorTermsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+        size: '10',
+        fieldName: 'error.grouping_key',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing fieldName', () => {
+    const result = mobileErrorTermsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+        size: '10',
+      },
+    });
+
+    expectParseError(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    const result = mobileErrorTermsRoute.params!.safeParse({
+      path: {},
+      query: {
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+        size: '10',
+        fieldName: 'error.grouping_key',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileErrorsDetailedStatisticsRoute params', () => {
+  it('accepts valid path, query and body', () => {
+    const result = mobileErrorsDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { groupIds: JSON.stringify(['groupId1', 'groupId2']) },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a body with a non-JSON groupIds', () => {
+    const result = mobileErrorsDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { groupIds: 'not-json' },
+    });
+
+    expectParseError(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    const result = mobileErrorsDetailedStatisticsRoute.params!.safeParse({
+      path: {},
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { groupIds: JSON.stringify(['groupId1']) },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileErrorsMainStatisticsRoute params', () => {
+  it('accepts a query without optional sort fields', () => {
+    const result = mobileErrorsMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts a query with sortField/sortDirection', () => {
+    const result = mobileErrorsMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        sortField: 'occurrences',
+        sortDirection: 'desc',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an invalid sortDirection', () => {
+    const result = mobileErrorsMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        sortDirection: 'invalid',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileHttpErrorRateRoute params', () => {
+  it('accepts a query without an optional offset', () => {
+    const result = mobileHttpErrorRateRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts a query with an optional offset', () => {
+    const result = mobileHttpErrorRateRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        offset: '1d',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    const result = mobileHttpErrorRateRoute.params!.safeParse({
+      path: {},
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_http_error_rate.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile_errors/mobile_http_error_rate.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface MobileHttpErrorsTimeseries {
   currentPeriod: { timeseries: Coordinate[] };
@@ -17,10 +17,10 @@ export interface MobileHttpErrorsTimeseries {
 
 export const mobileHttpErrorRateRoute = defineRoute<MobileHttpErrorsTimeseries>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/error/http_error_rate',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
+    query: environmentSchema.merge(kuerySchema).merge(rangeSchema).merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/flamegraph.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/flamegraph.ts
@@ -4,24 +4,22 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { BaseFlameGraph } from '@kbn/profiling-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type ServicesFlamegraphResponse = BaseFlameGraph;
 
 export const servicesFlamegraphRoute = defineRoute<ServicesFlamegraphResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/profiling/flamegraph',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      kueryRt,
-      environmentRt,
-      rangeRt,
-      t.partial({ transactionName: t.string }),
-      t.type({ transactionType: t.string }),
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: kuerySchema
+      .merge(environmentSchema)
+      .merge(rangeSchema)
+      .merge(z.object({ transactionName: z.string().optional() }))
+      .merge(z.object({ transactionType: z.string() })),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/functions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/functions.ts
@@ -4,29 +4,28 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { TopNFunctions } from '@kbn/profiling-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type ServicesFunctionsResponse = TopNFunctions;
 
 export const servicesFunctionsRoute = defineRoute<ServicesFunctionsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/profiling/functions',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      environmentRt,
-      rangeRt,
-      t.partial({ transactionName: t.string }),
-      t.type({
-        startIndex: toNumberRt,
-        endIndex: toNumberRt,
-        transactionType: t.string,
-      }),
-      kueryRt,
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: environmentSchema
+      .merge(rangeSchema)
+      .merge(z.object({ transactionName: z.string().optional() }))
+      .merge(
+        z.object({
+          startIndex: z.coerce.number(),
+          endIndex: z.coerce.number(),
+          transactionType: z.string(),
+        })
+      )
+      .merge(kuerySchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/hosts_flamegraph.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/hosts_flamegraph.ts
@@ -4,11 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { BaseFlameGraph } from '@kbn/profiling-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt, serviceTransactionDataSourceRt } from '../../default_api_types';
+import {
+  rangeSchema,
+  kuerySchema,
+  serviceTransactionDataSourceSchema,
+} from '../../default_api_types';
 
 export interface ProfilingHostsFlamegraphResponse {
   flamegraph: BaseFlameGraph;
@@ -18,8 +22,11 @@ export interface ProfilingHostsFlamegraphResponse {
 
 export const profilingHostsFlamegraphRoute = defineRoute<ProfilingHostsFlamegraphResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/profiling/hosts/flamegraph',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([rangeRt, environmentRt, serviceTransactionDataSourceRt, kueryRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema
+      .merge(environmentSchema)
+      .merge(serviceTransactionDataSourceSchema)
+      .merge(kuerySchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/hosts_functions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/hosts_functions.ts
@@ -4,12 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { TopNFunctions } from '@kbn/profiling-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt, serviceTransactionDataSourceRt } from '../../default_api_types';
+import {
+  rangeSchema,
+  kuerySchema,
+  serviceTransactionDataSourceSchema,
+} from '../../default_api_types';
 
 export interface ProfilingHostsFunctionsResponse {
   functions: TopNFunctions;
@@ -19,14 +22,12 @@ export interface ProfilingHostsFunctionsResponse {
 
 export const profilingHostsFunctionsRoute = defineRoute<ProfilingHostsFunctionsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/profiling/hosts/functions',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      rangeRt,
-      environmentRt,
-      serviceTransactionDataSourceRt,
-      t.type({ startIndex: toNumberRt, endIndex: toNumberRt }),
-      kueryRt,
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema
+      .merge(environmentSchema)
+      .merge(serviceTransactionDataSourceSchema)
+      .merge(z.object({ startIndex: z.coerce.number(), endIndex: z.coerce.number() }))
+      .merge(kuerySchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/profiling_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/profiling/profiling_params.test.ts
@@ -1,0 +1,155 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { ApmDocumentType, RollupInterval } from '@kbn/apm-types';
+import { servicesFlamegraphRoute } from './flamegraph';
+import { servicesFunctionsRoute } from './functions';
+import { profilingHostsFlamegraphRoute } from './hosts_flamegraph';
+import { profilingHostsFunctionsRoute } from './hosts_functions';
+
+describe('servicesFlamegraphRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = servicesFlamegraphRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        kuery: '',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        transactionType: 'request',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing transactionType', () => {
+    const result = servicesFlamegraphRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        kuery: '',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('servicesFunctionsRoute params', () => {
+  it('accepts a valid path and query, coercing indices to numbers', () => {
+    const result = servicesFunctionsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        kuery: '',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        startIndex: '0',
+        endIndex: '10',
+        transactionType: 'request',
+      },
+    });
+
+    expectParseSuccess(result);
+    expect(result.data?.query.startIndex).toBe(0);
+    expect(result.data?.query.endIndex).toBe(10);
+  });
+
+  it('rejects a missing serviceName', () => {
+    const result = servicesFunctionsRoute.params!.safeParse({
+      path: {},
+      query: {
+        kuery: '',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        startIndex: '0',
+        endIndex: '10',
+        transactionType: 'request',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('profilingHostsFlamegraphRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = profilingHostsFlamegraphRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        kuery: '',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: ApmDocumentType.TransactionMetric,
+        rollupInterval: RollupInterval.OneMinute,
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an invalid documentType', () => {
+    const result = profilingHostsFlamegraphRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        kuery: '',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'notARealDocumentType',
+        rollupInterval: RollupInterval.OneMinute,
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('profilingHostsFunctionsRoute params', () => {
+  it('accepts a valid path and query, coercing indices to numbers', () => {
+    const result = profilingHostsFunctionsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        kuery: '',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: ApmDocumentType.TransactionMetric,
+        rollupInterval: RollupInterval.OneMinute,
+        startIndex: '0',
+        endIndex: '10',
+      },
+    });
+
+    expectParseSuccess(result);
+    expect(result.data?.query.startIndex).toBe(0);
+    expect(result.data?.query.endIndex).toBe(10);
+  });
+
+  it('rejects a missing rollupInterval', () => {
+    const result = profilingHostsFunctionsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        kuery: '',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: ApmDocumentType.TransactionMetric,
+        startIndex: '0',
+        endIndex: '10',
+      },
+    });
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/dependency_node.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/dependency_node.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { NodeStats } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, offsetRt } from '../../default_api_types';
+import { rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface ServiceMapServiceDependencyInfoResponse {
   currentPeriod: NodeStats;
@@ -18,16 +18,15 @@ export interface ServiceMapServiceDependencyInfoResponse {
 export const serviceMapDependencyNodeRoute = defineRoute<ServiceMapServiceDependencyInfoResponse>()(
   {
     endpoint: 'GET /internal/apm/service-map/dependency',
-    params: t.type({
-      query: t.intersection([
-        t.type({
-          dependencies: t.union([t.string, t.array(t.string)]),
-        }),
-        t.partial({ sourceServiceName: t.string }),
-        environmentRt,
-        rangeRt,
-        offsetRt,
-      ]),
+    params: z.object({
+      query: z
+        .object({
+          dependencies: z.union([z.string(), z.array(z.string())]),
+        })
+        .merge(z.object({ sourceServiceName: z.string() }).partial())
+        .merge(environmentSchema)
+        .merge(rangeSchema)
+        .merge(offsetSchema),
     }),
   }
 );

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_badges.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_badges.ts
@@ -4,13 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { SloStatus } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import type { ServiceAlertsResponse } from '../services/service_alerts_count';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export type ServiceSloStatsResponse = Array<{
   serviceName: string;
@@ -25,8 +24,20 @@ export interface ServiceMapServiceBadgesResponse {
 
 export const serviceMapServiceBadgesRoute = defineRoute<ServiceMapServiceBadgesResponse>()({
   endpoint: 'POST /internal/apm/service-map/service_badges',
-  params: t.type({
-    query: t.intersection([environmentRt, rangeRt, t.partial({ kuery: t.string })]),
-    body: t.type({ serviceNames: jsonRt.pipe(t.array(t.string)) }),
+  params: z.object({
+    query: environmentSchema.merge(rangeSchema).merge(z.object({ kuery: z.string() }).partial()),
+    body: z.object({
+      serviceNames: z
+        .string()
+        .transform((value, ctx) => {
+          try {
+            return JSON.parse(value);
+          } catch (err) {
+            ctx.addIssue({ code: 'custom', message: err.message });
+            return z.NEVER;
+          }
+        })
+        .pipe(z.array(z.string())),
+    }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_map.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_map.ts
@@ -4,29 +4,35 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { ServiceMapResponse } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
-import { jsonRt } from '@kbn/io-ts-utils';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export type ServiceMapRouteResponse = ServiceMapResponse;
 
 export const serviceMapRoute = defineRoute<ServiceMapRouteResponse>()({
   endpoint: 'GET /internal/apm/service-map',
-  params: t.type({
-    query: t.intersection([
-      t.partial({
-        serviceName: t.string,
-        serviceGroup: t.string,
-        kuery: kueryRt.props.kuery,
+  params: z.object({
+    query: z
+      .object({
+        serviceName: z.string(),
+        serviceGroup: z.string(),
+        kuery: z.string(),
         // JSON-serialised ES query produced by buildEsQuery() on the client.
         // Carries filter-bar pills + Controls API selections already merged.
-        esQuery: jsonRt,
-      }),
-      environmentRt,
-      rangeRt,
-    ]),
+        esQuery: z.string().transform((value, ctx) => {
+          try {
+            return JSON.parse(value);
+          } catch (err) {
+            ctx.addIssue({ code: 'custom', message: err.message });
+            return z.NEVER;
+          }
+        }),
+      })
+      .partial()
+      .merge(environmentSchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_map_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/service_map/service_map_params.test.ts
@@ -1,0 +1,144 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { serviceMapRoute } from './service_map';
+import { serviceMapDependencyNodeRoute } from './dependency_node';
+import { serviceMapServiceBadgesRoute } from './service_badges';
+
+describe('serviceMapRoute params', () => {
+  it('accepts a query with no optional fields', () => {
+    const result = serviceMapRoute.params!.safeParse({
+      query: { environment: 'production', start: '2021-01-01', end: '2021-01-02' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts a query with esQuery, kuery, serviceName and serviceGroup', () => {
+    const result = serviceMapRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        serviceName: 'opbeans-java',
+        serviceGroup: 'my-group',
+        kuery: 'service.name: "opbeans-java"',
+        esQuery: JSON.stringify({ bool: { filter: [] } }),
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.query.esQuery).toEqual({ bool: { filter: [] } });
+    }
+  });
+
+  it('rejects an invalid esQuery', () => {
+    expectParseError(
+      serviceMapRoute.params!.safeParse({
+        query: {
+          environment: 'production',
+          start: '2021-01-01',
+          end: '2021-01-02',
+          esQuery: 'not-json',
+        },
+      })
+    );
+  });
+
+  it('rejects a missing environment', () => {
+    expectParseError(
+      serviceMapRoute.params!.safeParse({
+        query: { start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+});
+
+describe('serviceMapDependencyNodeRoute params', () => {
+  it('accepts a single dependency', () => {
+    const result = serviceMapDependencyNodeRoute.params!.safeParse({
+      query: {
+        dependencies: 'postgresql',
+        environment: 'production',
+        start: '2021-01-01',
+        end: '2021-01-02',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an array of dependencies plus optional sourceServiceName/offset', () => {
+    const result = serviceMapDependencyNodeRoute.params!.safeParse({
+      query: {
+        dependencies: ['postgresql', 'redis'],
+        sourceServiceName: 'opbeans-java',
+        offset: '1d',
+        environment: 'production',
+        start: '2021-01-01',
+        end: '2021-01-02',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing dependencies field', () => {
+    expectParseError(
+      serviceMapDependencyNodeRoute.params!.safeParse({
+        query: { environment: 'production', start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+});
+
+describe('serviceMapServiceBadgesRoute params', () => {
+  it('accepts a query/body with serviceNames as a JSON array', () => {
+    const result = serviceMapServiceBadgesRoute.params!.safeParse({
+      query: { environment: 'production', start: '2021-01-01', end: '2021-01-02' },
+      body: { serviceNames: JSON.stringify(['opbeans-java', 'opbeans-node']) },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.body.serviceNames).toEqual(['opbeans-java', 'opbeans-node']);
+    }
+  });
+
+  it('accepts an optional kuery', () => {
+    const result = serviceMapServiceBadgesRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        start: '2021-01-01',
+        end: '2021-01-02',
+        kuery: 'service.name: "opbeans-java"',
+      },
+      body: { serviceNames: JSON.stringify(['opbeans-java']) },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a non-JSON serviceNames body', () => {
+    expectParseError(
+      serviceMapServiceBadgesRoute.params!.safeParse({
+        query: { environment: 'production', start: '2021-01-01', end: '2021-01-02' },
+        body: { serviceNames: 'not-json' },
+      })
+    );
+  });
+
+  it('rejects a missing body', () => {
+    expectParseError(
+      serviceMapServiceBadgesRoute.params!.safeParse({
+        query: { environment: 'production', start: '2021-01-01', end: '2021-01-02' },
+      })
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/delete_source_map.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/delete_source_map.ts
@@ -4,14 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
 
 export const deleteSourceMapRoute = defineRoute<void>()({
   endpoint: 'DELETE /api/apm/sourcemaps/{id} 2023-10-31',
-  params: t.type({
-    path: t.type({
-      id: t.string,
+  params: z.object({
+    path: z.object({
+      id: z.string(),
     }),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/index.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/index.ts
@@ -16,5 +16,5 @@ export const sourceMapsRouteDefinitions = {
   migrateFleetArtifacts: migrateFleetArtifactsRoute,
 };
 
-export { sourceMapRt, type SourceMap, type ApmSourceMapArtifactBody } from './source_map_types';
+export { sourceMapSchema, type SourceMap, type ApmSourceMapArtifactBody } from './source_map_types';
 export type { ListSourceMapArtifactsResponse } from './list_source_maps';

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/list_source_maps.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/list_source_maps.ts
@@ -4,8 +4,7 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
 import type { ApmSourceMapArtifactBody } from './source_map_types';
 
@@ -29,10 +28,12 @@ export interface ListSourceMapArtifactsResponse {
 }
 export const listSourceMapsRoute = defineRoute<ListSourceMapArtifactsResponse | undefined>()({
   endpoint: 'GET /api/apm/sourcemaps 2023-10-31',
-  params: t.partial({
-    query: t.partial({
-      page: toNumberRt,
-      perPage: toNumberRt,
-    }),
+  params: z.object({
+    query: z
+      .object({
+        page: z.coerce.number().optional(),
+        perPage: z.coerce.number().optional(),
+      })
+      .optional(),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/source_map_types.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/source_map_types.ts
@@ -4,23 +4,22 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 
-export const sourceMapRt = t.intersection([
-  t.type({
-    version: t.number,
-    sources: t.array(t.string),
-    mappings: t.string,
-  }),
-  t.partial({
-    names: t.array(t.string),
-    file: t.string,
-    sourceRoot: t.string,
-    sourcesContent: t.array(t.union([t.string, t.null])),
-  }),
-]);
+export const sourceMapSchema = z
+  .object({
+    version: z.number(),
+    sources: z.array(z.string()),
+    mappings: z.string(),
+  })
+  .extend({
+    names: z.array(z.string()).optional(),
+    file: z.string().optional(),
+    sourceRoot: z.string().optional(),
+    sourcesContent: z.array(z.union([z.string(), z.null()])).optional(),
+  });
 
-export type SourceMap = t.TypeOf<typeof sourceMapRt>;
+export type SourceMap = z.infer<typeof sourceMapSchema>;
 
 export interface ApmSourceMapArtifactBody {
   serviceName: string;

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/source_maps_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/source_maps_params.test.ts
@@ -1,0 +1,106 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { deleteSourceMapRoute } from './delete_source_map';
+import { listSourceMapsRoute } from './list_source_maps';
+import { uploadSourceMapRoute } from './upload_source_map';
+
+describe('deleteSourceMapRoute params', () => {
+  it('accepts a path id', () => {
+    const result = deleteSourceMapRoute.params!.safeParse({ path: { id: 'abc123' } });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing path id', () => {
+    expectParseError(deleteSourceMapRoute.params!.safeParse({ path: {} }));
+  });
+});
+
+describe('listSourceMapsRoute params', () => {
+  it('allows an entirely missing query', () => {
+    expectParseSuccess(listSourceMapsRoute.params!.safeParse({}));
+  });
+
+  it('coerces page and perPage to numbers', () => {
+    const result = listSourceMapsRoute.params!.safeParse({
+      query: { page: '2', perPage: '10' },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data).toEqual({ query: { page: 2, perPage: 10 } });
+    }
+  });
+
+  it('rejects a non-numeric page', () => {
+    expectParseError(listSourceMapsRoute.params!.safeParse({ query: { page: 'not-a-number' } }));
+  });
+});
+
+describe('uploadSourceMapRoute params', () => {
+  const validSourceMap = {
+    version: 3,
+    sources: ['foo.js'],
+    mappings: 'AAAA',
+  };
+
+  it('accepts a valid body with a JSON string sourcemap', () => {
+    const result = uploadSourceMapRoute.params!.safeParse({
+      body: {
+        service_name: 'opbeans-java',
+        service_version: '1.0.0',
+        bundle_filepath: '/foo/bar.js',
+        sourcemap: JSON.stringify(validSourceMap),
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.body.sourcemap).toEqual(validSourceMap);
+    }
+  });
+
+  it('rejects a sourcemap that is not valid JSON', () => {
+    expectParseError(
+      uploadSourceMapRoute.params!.safeParse({
+        body: {
+          service_name: 'opbeans-java',
+          service_version: '1.0.0',
+          bundle_filepath: '/foo/bar.js',
+          sourcemap: 'not-json',
+        },
+      })
+    );
+  });
+
+  it('rejects a sourcemap missing required fields', () => {
+    expectParseError(
+      uploadSourceMapRoute.params!.safeParse({
+        body: {
+          service_name: 'opbeans-java',
+          service_version: '1.0.0',
+          bundle_filepath: '/foo/bar.js',
+          sourcemap: JSON.stringify({ version: 3 }),
+        },
+      })
+    );
+  });
+
+  it('rejects a missing body field', () => {
+    expectParseError(
+      uploadSourceMapRoute.params!.safeParse({
+        body: {
+          service_version: '1.0.0',
+          bundle_filepath: '/foo/bar.js',
+          sourcemap: JSON.stringify(validSourceMap),
+        },
+      })
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/upload_source_map.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/source_maps/upload_source_map.ts
@@ -4,20 +4,31 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, stringFromBufferRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { Artifact } from '@kbn/fleet-plugin/server';
 import { defineRoute } from '../types';
-import { sourceMapRt } from './source_map_types';
+import { sourceMapSchema } from './source_map_types';
 
 export const uploadSourceMapRoute = defineRoute<Artifact | undefined>()({
   endpoint: 'POST /api/apm/sourcemaps 2023-10-31',
-  params: t.type({
-    body: t.type({
-      service_name: t.string,
-      service_version: t.string,
-      bundle_filepath: t.string,
-      sourcemap: t.union([t.string, stringFromBufferRt]).pipe(jsonRt).pipe(sourceMapRt),
+  params: z.object({
+    body: z.object({
+      service_name: z.string(),
+      service_version: z.string(),
+      bundle_filepath: z.string(),
+      sourcemap: z
+        .union([z.string(), z.instanceof(Buffer).transform((buf) => buf.toString('utf-8'))])
+        .pipe(
+          z.string().transform((value, ctx) => {
+            try {
+              return JSON.parse(value);
+            } catch (err) {
+              ctx.addIssue({ code: 'custom', message: err.message });
+              return z.NEVER;
+            }
+          })
+        )
+        .pipe(sourceMapSchema),
     }),
   }),
 });


### PR DESCRIPTION
## Summary

Part of the `io-ts` -> `@kbn/zod` migration tracked in elastic/kibana#243355.

Stacked on the agent_configuration PR (jennypavlova/kibana#27, already merged into this branch) — still opened against the fork's `apm/migrate-io-ts-to-zod-batch-12-groups` branch since elastic/kibana#277145 is still open upstream. Will be rebased and reopened against `elastic/kibana:main` once that merges.

Converts 8 route groups (39 route files) to zod params:
- `correlations` (6 files + `types.ts`)
- `errors` (6 files)
- `metrics` (6 files)
- `mobile_crashes` (3 files)
- `mobile_errors` (4 files)
- `profiling` (4 files, `status.ts` had no params)
- `service_map` (3 files)
- `source_maps` (4 files)

All groups reuse the shared additive zod schemas from `default_api_types.ts` (`rangeSchema`, `kuerySchema`, `offsetSchema`, `probabilitySchema`, `serviceTransactionDataSourceSchema`, `transactionDataSourceSchema`) and `@kbn/apm-types` (`environmentSchema`) — zero existing io-ts consumers of those shared codecs were touched.

Two group-local codecs with no consumers outside their own file/group were fully renamed (not kept additive) after confirming via grep:
- `sourceMapRt` -> `sourceMapSchema` (`source_maps/source_map_types.ts`, only consumer was `upload_source_map.ts` in the same group)
- `entityTypeRt`/`metricRt` -> `entityTypeSchema`/`metricSchema` (`correlations/types.ts`, only consumer was `unified_correlations.ts` in the same group)

`io-ts-utils` replacements used: `toNumberRt` -> `z.coerce.number()`, `toBooleanRt` -> `BooleanFromString`, `jsonRt.pipe(x)` -> a local JSON-parse-transform piped into the zod equivalent of `x`, and the `stringFromBufferRt` + `jsonRt` + `sourceMapRt` pipe chain in `upload_source_map.ts` -> a `z.union([z.string(), z.instanceof(Buffer).transform(...)])` chain piped through the same JSON-parse transform into `sourceMapSchema`.

## Test plan

- [x] Added one `<group>_params.test.ts` per group (91 new test cases total across the 8 files), covering success + failure cases per route.
- [x] Full `kbn-apm-api-shared` jest suite passes: 27 suites, 192/192 tests.
- [x] `eslint` clean on all touched files.
- [x] Type-check clean via the oblt CLI for `kbn-apm-api-shared` and the `apm` plugin (0 errors).
- [x] `node scripts/lint_ts_projects.js` clean.
- [ ] No FTR spec coverage added/re-run for these groups in this PR — relying on the unit test coverage above plus manual verification via Kibana Dev Tools Console.