### PR TITLE
[APM] Migrate final 5 route groups to zod (io-ts -> zod migration, part 10)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/dependencies_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/dependencies_params.test.ts
@@ -1,0 +1,353 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { dependencyErrorRateChartsRoute } from './error_rate_charts';
+import { dependencyLatencyChartsRoute } from './latency_charts';
+import { dependencyThroughputChartsRoute } from './throughput_charts';
+import { dependencyLatencyDistributionRoute } from './latency_distribution';
+import { dependencyMetadataRoute } from './metadata';
+import { dependencyOperationsRoute } from './operations';
+import { topDependenciesStatisticsRoute } from './top_dependencies_statistics';
+import { topDependenciesRoute } from './top_dependencies';
+import { topDependencySpansRoute } from './top_dependency_spans';
+import { upstreamServicesRoute } from './upstream_services';
+
+const validDependencyChartQuery = {
+  dependencyName: 'postgresql',
+  spanName: 'SELECT',
+  searchServiceDestinationMetrics: 'true',
+  start: '2021-01-01T00:00:00.000Z',
+  end: '2021-01-08T00:00:00.000Z',
+  kuery: '',
+  environment: 'production',
+};
+
+describe('dependencyErrorRateChartsRoute params', () => {
+  it('accepts a valid query', () => {
+    const result = dependencyErrorRateChartsRoute.params!.safeParse({
+      query: validDependencyChartQuery,
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing required fields', () => {
+    const result = dependencyErrorRateChartsRoute.params!.safeParse({
+      query: { dependencyName: 'postgresql' },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('dependencyLatencyChartsRoute params', () => {
+  it('accepts a valid query', () => {
+    const result = dependencyLatencyChartsRoute.params!.safeParse({
+      query: validDependencyChartQuery,
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing required fields', () => {
+    const result = dependencyLatencyChartsRoute.params!.safeParse({
+      query: { spanName: 'SELECT' },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('dependencyThroughputChartsRoute params', () => {
+  it('accepts a valid query', () => {
+    const result = dependencyThroughputChartsRoute.params!.safeParse({
+      query: validDependencyChartQuery,
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an entirely missing query', () => {
+    const result = dependencyThroughputChartsRoute.params!.safeParse({});
+
+    expectParseError(result);
+  });
+});
+
+describe('dependencyLatencyDistributionRoute params', () => {
+  it('accepts a valid query', () => {
+    const result = dependencyLatencyDistributionRoute.params!.safeParse({
+      query: {
+        dependencyName: 'postgresql',
+        spanName: 'SELECT',
+        percentileThreshold: '95',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a non-numeric percentileThreshold', () => {
+    const result = dependencyLatencyDistributionRoute.params!.safeParse({
+      query: {
+        dependencyName: 'postgresql',
+        spanName: 'SELECT',
+        percentileThreshold: 'not-a-number',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('dependencyMetadataRoute params', () => {
+  it('accepts a valid query', () => {
+    const result = dependencyMetadataRoute.params!.safeParse({
+      query: {
+        dependencyName: 'postgresql',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing dependencyName', () => {
+    const result = dependencyMetadataRoute.params!.safeParse({
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('dependencyOperationsRoute params', () => {
+  it('accepts a valid query', () => {
+    const result = dependencyOperationsRoute.params!.safeParse({
+      query: {
+        dependencyName: 'postgresql',
+        searchServiceDestinationMetrics: 'false',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a non-boolean searchServiceDestinationMetrics', () => {
+    const result = dependencyOperationsRoute.params!.safeParse({
+      query: {
+        dependencyName: 'postgresql',
+        searchServiceDestinationMetrics: 'not-a-boolean',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('topDependenciesStatisticsRoute params', () => {
+  it('accepts a valid query and body', () => {
+    const result = topDependenciesStatisticsRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { dependencyNames: JSON.stringify(['postgresql', 'redis']) },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a body with an invalid JSON string', () => {
+    const result = topDependenciesStatisticsRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { dependencyNames: 'not-json' },
+    });
+
+    expectParseError(result);
+  });
+
+  it('rejects a body whose parsed JSON is not an array of strings', () => {
+    const result = topDependenciesStatisticsRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        numBuckets: '20',
+      },
+      body: { dependencyNames: JSON.stringify([1, 2, 3]) },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('topDependenciesRoute params', () => {
+  it('accepts a valid query', () => {
+    const result = topDependenciesRoute.params!.safeParse({
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        environment: 'production',
+        kuery: '',
+        numBuckets: '20',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing numBuckets', () => {
+    const result = topDependenciesRoute.params!.safeParse({
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        environment: 'production',
+        kuery: '',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('topDependencySpansRoute params', () => {
+  it('accepts a valid query without the optional sample range', () => {
+    const result = topDependencySpansRoute.params!.safeParse({
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        environment: 'production',
+        kuery: '',
+        dependencyName: 'postgresql',
+        spanName: 'SELECT',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts a valid query with the optional sample range', () => {
+    const result = topDependencySpansRoute.params!.safeParse({
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        environment: 'production',
+        kuery: '',
+        dependencyName: 'postgresql',
+        spanName: 'SELECT',
+        sampleRangeFrom: '0',
+        sampleRangeTo: '100',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing spanName', () => {
+    const result = topDependencySpansRoute.params!.safeParse({
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        environment: 'production',
+        kuery: '',
+        dependencyName: 'postgresql',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('upstreamServicesRoute params', () => {
+  it('rejects a query missing the required environment/kuery fields', () => {
+    const result = upstreamServicesRoute.params!.safeParse({
+      query: {
+        dependencyName: 'postgresql',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        numBuckets: '20',
+      },
+    });
+
+    expectParseError(result);
+  });
+
+  it('accepts a query without the optional offset field', () => {
+    const result = upstreamServicesRoute.params!.safeParse({
+      query: {
+        dependencyName: 'postgresql',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        numBuckets: '20',
+        environment: 'production',
+        kuery: '',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts a query with the optional environment/offset/kuery fields', () => {
+    const result = upstreamServicesRoute.params!.safeParse({
+      query: {
+        dependencyName: 'postgresql',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        numBuckets: '20',
+        environment: 'production',
+        offset: '1d',
+        kuery: '',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing dependencyName', () => {
+    const result = upstreamServicesRoute.params!.safeParse({
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-08T00:00:00.000Z',
+        numBuckets: '20',
+      },
+    });
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/error_rate_charts.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/error_rate_charts.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
-import { dependencyChartQueryRt } from './types';
+import { dependencyChartQuerySchema } from './types';
 
 export interface DependencyErrorRateChartsResponse {
   currentTimeseries: Array<{ x: number; y: number }>;
@@ -15,5 +15,5 @@ export interface DependencyErrorRateChartsResponse {
 
 export const dependencyErrorRateChartsRoute = defineRoute<DependencyErrorRateChartsResponse>()({
   endpoint: 'GET /internal/apm/dependencies/charts/error_rate',
-  params: t.type({ query: dependencyChartQueryRt }),
+  params: z.object({ query: dependencyChartQuerySchema }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/latency_charts.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/latency_charts.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
-import { dependencyChartQueryRt } from './types';
+import { dependencyChartQuerySchema } from './types';
 
 export interface LatencyChartsDependencyResponse {
   currentTimeseries: Array<{ x: number; y: number }>;
@@ -15,5 +15,5 @@ export interface LatencyChartsDependencyResponse {
 
 export const dependencyLatencyChartsRoute = defineRoute<LatencyChartsDependencyResponse>()({
   endpoint: 'GET /internal/apm/dependencies/charts/latency',
-  params: t.type({ query: dependencyChartQueryRt }),
+  params: z.object({ query: dependencyChartQuerySchema }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/latency_distribution.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/latency_distribution.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { OverallLatencyDistributionResponse } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt } from '../../default_api_types';
+import { rangeSchema, kuerySchema } from '../../default_api_types';
 
 export interface DependencyLatencyDistributionResponse {
   allSpansDistribution: OverallLatencyDistributionResponse;
@@ -19,16 +18,15 @@ export interface DependencyLatencyDistributionResponse {
 export const dependencyLatencyDistributionRoute =
   defineRoute<DependencyLatencyDistributionResponse>()({
     endpoint: 'GET /internal/apm/dependencies/charts/distribution',
-    params: t.type({
-      query: t.intersection([
-        t.type({
-          dependencyName: t.string,
-          spanName: t.string,
-          percentileThreshold: toNumberRt,
-        }),
-        rangeRt,
-        kueryRt,
-        environmentRt,
-      ]),
+    params: z.object({
+      query: z
+        .object({
+          dependencyName: z.string(),
+          spanName: z.string(),
+          percentileThreshold: z.coerce.number(),
+        })
+        .merge(rangeSchema)
+        .merge(kuerySchema)
+        .merge(environmentSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/metadata.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/metadata.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface MetadataForDependencyResponse {
   spanType: string | undefined;
@@ -19,7 +19,7 @@ export interface DependencyMetadataRouteResponse {
 
 export const dependencyMetadataRoute = defineRoute<DependencyMetadataRouteResponse>()({
   endpoint: 'GET /internal/apm/dependencies/metadata',
-  params: t.type({
-    query: t.intersection([t.type({ dependencyName: t.string }), rangeRt]),
+  params: z.object({
+    query: z.object({ dependencyName: z.string() }).merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/operations.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/operations.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toBooleanRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt, offsetRt } from '../../default_api_types';
+import { rangeSchema, kuerySchema, offsetSchema } from '../../default_api_types';
 
 export interface DependencyOperation {
   spanName: string;
@@ -28,16 +28,16 @@ export interface DependencyOperationsResponse {
 
 export const dependencyOperationsRoute = defineRoute<DependencyOperationsResponse>()({
   endpoint: 'GET /internal/apm/dependencies/operations',
-  params: t.type({
-    query: t.intersection([
-      rangeRt,
-      environmentRt,
-      kueryRt,
-      offsetRt,
-      t.type({
-        dependencyName: t.string,
-        searchServiceDestinationMetrics: toBooleanRt,
-      }),
-    ]),
+  params: z.object({
+    query: rangeSchema
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(offsetSchema)
+      .merge(
+        z.object({
+          dependencyName: z.string(),
+          searchServiceDestinationMetrics: BooleanFromString,
+        })
+      ),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/throughput_charts.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/throughput_charts.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
-import { dependencyChartQueryRt } from './types';
+import { dependencyChartQuerySchema } from './types';
 
 export interface ThroughputChartsForDependencyResponse {
   currentTimeseries: Array<{ x: number; y: number | null }>;
@@ -16,6 +16,6 @@ export interface ThroughputChartsForDependencyResponse {
 export const dependencyThroughputChartsRoute = defineRoute<ThroughputChartsForDependencyResponse>()(
   {
     endpoint: 'GET /internal/apm/dependencies/charts/throughput',
-    params: t.type({ query: dependencyChartQueryRt }),
+    params: z.object({ query: dependencyChartQuerySchema }),
   }
 );

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependencies.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependencies.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { ConnectionStats, Node } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt } from '../../default_api_types';
+import { rangeSchema, kuerySchema } from '../../default_api_types';
 
 export interface TopDependenciesResponse {
   dependencies: Array<{
@@ -22,7 +21,10 @@ export interface TopDependenciesResponse {
 
 export const topDependenciesRoute = defineRoute<TopDependenciesResponse>()({
   endpoint: 'GET /internal/apm/dependencies/top_dependencies',
-  params: t.type({
-    query: t.intersection([rangeRt, environmentRt, kueryRt, t.type({ numBuckets: toNumberRt })]),
+  params: z.object({
+    query: rangeSchema
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(z.object({ numBuckets: z.coerce.number() })),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependencies_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependencies_statistics.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 interface Statistics {
   latency: Array<{ x: number; y: number }>;
@@ -21,14 +20,29 @@ export interface DependenciesTimeseriesStatisticsResponse {
   comparisonTimeseries: Record<string, Statistics> | null;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value is an array of strings.
+const dependencyNamesJsonSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const topDependenciesStatisticsRoute =
   defineRoute<DependenciesTimeseriesStatisticsResponse>()({
     endpoint: 'POST /internal/apm/dependencies/top_dependencies/statistics',
-    params: t.type({
-      query: t.intersection([
-        t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
-        t.type({ numBuckets: toNumberRt }),
-      ]),
-      body: t.type({ dependencyNames: jsonRt.pipe(t.array(t.string)) }),
+    params: z.object({
+      query: environmentSchema
+        .merge(kuerySchema)
+        .merge(rangeSchema)
+        .merge(offsetSchema)
+        .merge(z.object({ numBuckets: z.coerce.number() })),
+      body: z.object({ dependencyNames: dependencyNamesJsonSchema }),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependency_spans.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/top_dependency_spans.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { AgentName, EventOutcome } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt } from '../../default_api_types';
+import { rangeSchema, kuerySchema } from '../../default_api_types';
 
 export interface DependencySpan {
   '@timestamp': number;
@@ -31,13 +30,16 @@ export interface TopDependencySpansResponse {
 
 export const topDependencySpansRoute = defineRoute<TopDependencySpansResponse>()({
   endpoint: 'GET /internal/apm/dependencies/operations/spans',
-  params: t.type({
-    query: t.intersection([
-      rangeRt,
-      environmentRt,
-      kueryRt,
-      t.type({ dependencyName: t.string, spanName: t.string }),
-      t.partial({ sampleRangeFrom: toNumberRt, sampleRangeTo: toNumberRt }),
-    ]),
+  params: z.object({
+    query: rangeSchema
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(z.object({ dependencyName: z.string(), spanName: z.string() }))
+      .merge(
+        z.object({
+          sampleRangeFrom: z.coerce.number().optional(),
+          sampleRangeTo: z.coerce.number().optional(),
+        })
+      ),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/types.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/types.ts
@@ -4,19 +4,18 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toBooleanRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
+import { environmentSchema } from '@kbn/apm-types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
-export const dependencyChartQueryRt = t.intersection([
-  t.type({
-    dependencyName: t.string,
-    spanName: t.string,
-    searchServiceDestinationMetrics: toBooleanRt,
-  }),
-  rangeRt,
-  kueryRt,
-  environmentRt,
-  offsetRt,
-]);
+export const dependencyChartQuerySchema = z
+  .object({
+    dependencyName: z.string(),
+    spanName: z.string(),
+    searchServiceDestinationMetrics: BooleanFromString,
+  })
+  .merge(rangeSchema)
+  .merge(kuerySchema)
+  .merge(environmentSchema)
+  .merge(offsetSchema);

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/upstream_services.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/dependencies/upstream_services.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { ConnectionStats, Node } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt, offsetRt } from '../../default_api_types';
+import { rangeSchema, kuerySchema, offsetSchema } from '../../default_api_types';
 
 export interface UpstreamServicesForDependencyResponse {
   services: Array<{
@@ -21,16 +20,13 @@ export interface UpstreamServicesForDependencyResponse {
 
 export const upstreamServicesRoute = defineRoute<UpstreamServicesForDependencyResponse>()({
   endpoint: 'GET /internal/apm/dependencies/upstream_services',
-  params: t.intersection([
-    t.type({
-      query: t.intersection([
-        t.type({ dependencyName: t.string }),
-        rangeRt,
-        t.type({ numBuckets: toNumberRt }),
-      ]),
-    }),
-    t.partial({
-      query: t.intersection([environmentRt, offsetRt, kueryRt]),
-    }),
-  ]),
+  params: z.object({
+    query: z
+      .object({ dependencyName: z.string() })
+      .merge(rangeSchema)
+      .merge(z.object({ numBuckets: z.coerce.number() }))
+      .merge(environmentSchema)
+      .merge(offsetSchema)
+      .merge(kuerySchema),
+  }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_detailed_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_detailed_statistics.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import { type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface MobileDetailedStatistics {
   fieldName: string;
@@ -22,21 +21,34 @@ export interface MobileDetailedStatisticsResponse {
   previousPeriod: Record<string, MobileDetailedStatistics>;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value as an array of strings.
+const fieldValuesSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const mobileDetailedStatisticsRoute = defineRoute<MobileDetailedStatisticsResponse>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/detailed_statistics',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      offsetRt,
-      environmentRt,
-      t.type({
-        field: t.string,
-        fieldValues: jsonRt.pipe(t.array(t.string)),
-      }),
-    ]),
+    query: z
+      .object({
+        field: z.string(),
+        fieldValues: fieldValuesSchema,
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema)
+      .merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_filters.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_filters.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { type MobilePropertyType } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type MobileFiltersResponse = Array<{
   key: MobilePropertyType;
@@ -21,17 +21,16 @@ export interface MobileFiltersRouteResponse {
 
 export const mobileFiltersRoute = defineRoute<MobileFiltersRouteResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/mobile/filters',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      t.partial({
-        transactionType: t.string,
-      }),
-    ]),
+    query: z
+      .object({
+        transactionType: z.string().optional(),
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_http_requests.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_http_requests.ts
@@ -4,12 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { type Coordinate } from '@kbn/apm-types';
 
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface HttpRequestsTimeseries {
   currentPeriod: { timeseries: Coordinate[]; value: number | null | undefined };
@@ -18,19 +18,18 @@ export interface HttpRequestsTimeseries {
 
 export const mobileHttpRequestsRoute = defineRoute<HttpRequestsTimeseries>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/transactions/charts/http_requests',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      offsetRt,
-      t.partial({
-        transactionType: t.string,
-        transactionName: t.string,
-      }),
-    ]),
+    query: z
+      .object({
+        transactionType: z.string().optional(),
+        transactionName: z.string().optional(),
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(environmentSchema)
+      .merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_location_stats.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_location_stats.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import type { Maybe } from '@kbn/apm-types-shared';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 type Timeseries = Array<{ x: number; y: number }>;
 
@@ -42,18 +42,17 @@ export interface MobileLocationStats {
 
 export const mobileLocationStatsRoute = defineRoute<MobileLocationStats>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/location/stats',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      offsetRt,
-      t.partial({
-        locationField: t.string,
-      }),
-    ]),
+    query: z
+      .object({
+        locationField: z.string().optional(),
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(environmentSchema)
+      .merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_main_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_main_statistics.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface MobileMainStatisticsResponse {
   mainStatistics: Array<{
@@ -20,17 +20,16 @@ export interface MobileMainStatisticsResponse {
 
 export const mobileMainStatisticsRoute = defineRoute<MobileMainStatisticsResponse>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/main_statistics',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      t.type({
-        field: t.string,
-      }),
-    ]),
+    query: z
+      .object({
+        field: z.string(),
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_most_used_charts.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_most_used_charts.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { type MobilePropertyType } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type MobileMostUsedChartResponse = Array<{
   key: MobilePropertyType;
@@ -27,17 +27,16 @@ export interface MobileMostUsedChartsRouteResponse {
 
 export const mobileMostUsedChartsRoute = defineRoute<MobileMostUsedChartsRouteResponse>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/most_used_charts',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      t.partial({
-        transactionType: t.string,
-      }),
-    ]),
+    query: z
+      .object({
+        transactionType: z.string().optional(),
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_params.test.ts
@@ -1,0 +1,278 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { mobileDetailedStatisticsRoute } from './mobile_detailed_statistics';
+import { mobileFiltersRoute } from './mobile_filters';
+import { mobileHttpRequestsRoute } from './mobile_http_requests';
+import { mobileLocationStatsRoute } from './mobile_location_stats';
+import { mobileMainStatisticsRoute } from './mobile_main_statistics';
+import { mobileMostUsedChartsRoute } from './mobile_most_used_charts';
+import { mobileSessionsRoute } from './mobile_sessions';
+import { mobileStatsRoute } from './mobile_stats';
+import { mobileTermsByFieldRoute } from './mobile_terms_by_field';
+
+const range = {
+  start: '2021-01-01T00:00:00.000Z',
+  end: '2021-01-02T00:00:00.000Z',
+};
+
+describe('mobileDetailedStatisticsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = mobileDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+        field: 'device.manufacturer',
+        fieldValues: JSON.stringify(['Apple', 'Samsung']),
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects fieldValues that is not valid JSON', () => {
+    const result = mobileDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+        field: 'device.manufacturer',
+        fieldValues: 'not-json',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileFiltersRoute params', () => {
+  it('accepts a query without the optional transactionType', () => {
+    const result = mobileFiltersRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing the required kuery', () => {
+    const result = mobileFiltersRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        environment: 'production',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileHttpRequestsRoute params', () => {
+  it('accepts a minimal valid query', () => {
+    const result = mobileHttpRequestsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing environment', () => {
+    const result = mobileHttpRequestsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileLocationStatsRoute params', () => {
+  it('accepts a minimal valid query', () => {
+    const result = mobileLocationStatsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing start', () => {
+    const result = mobileLocationStatsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        end: range.end,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileMainStatisticsRoute params', () => {
+  it('accepts a query with the required field', () => {
+    const result = mobileMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+        field: 'device.manufacturer',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing the required field', () => {
+    const result = mobileMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileMostUsedChartsRoute params', () => {
+  it('accepts a query without the optional transactionType', () => {
+    const result = mobileMostUsedChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing kuery', () => {
+    const result = mobileMostUsedChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        environment: 'production',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileSessionsRoute params', () => {
+  it('accepts a minimal valid query', () => {
+    const result = mobileSessionsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing end', () => {
+    const result = mobileSessionsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        start: range.start,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileStatsRoute params', () => {
+  it('accepts a minimal valid query', () => {
+    const result = mobileStatsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing environment', () => {
+    const result = mobileStatsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('mobileTermsByFieldRoute params', () => {
+  it('accepts a query with size and fieldName, coercing size to a number', () => {
+    const result = mobileTermsByFieldRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+        size: '10',
+        fieldName: 'device.manufacturer',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing the required fieldName', () => {
+    const result = mobileTermsByFieldRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-swift' },
+      query: {
+        ...range,
+        kuery: '',
+        environment: 'production',
+        size: '10',
+      },
+    });
+
+    expectParseError(result);
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_sessions.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_sessions.ts
@@ -4,12 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface SessionsTimeseries {
   currentPeriod: { timeseries: Coordinate[]; value: number | null | undefined };
@@ -18,19 +18,18 @@ export interface SessionsTimeseries {
 
 export const mobileSessionsRoute = defineRoute<SessionsTimeseries>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/transactions/charts/sessions',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      offsetRt,
-      t.partial({
-        transactionType: t.string,
-        transactionName: t.string,
-      }),
-    ]),
+    query: z
+      .object({
+        transactionType: z.string().optional(),
+        transactionName: z.string().optional(),
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(environmentSchema)
+      .merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_stats.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_stats.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 interface MobileStatsTimeseries {
   x: number;
@@ -28,18 +28,17 @@ export interface MobilePeriodStats {
 
 export const mobileStatsRoute = defineRoute<MobilePeriodStats>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/stats',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      offsetRt,
-      t.partial({
-        transactionType: t.string,
-      }),
-    ]),
+    query: z
+      .object({
+        transactionType: z.string().optional(),
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(environmentSchema)
+      .merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_terms_by_field.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/mobile/mobile_terms_by_field.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export type MobileTermsByFieldResponse = Array<{
   label: string;
@@ -21,18 +20,17 @@ export interface MobileTermsByFieldRouteResponse {
 
 export const mobileTermsByFieldRoute = defineRoute<MobileTermsByFieldRouteResponse>()({
   endpoint: 'GET /internal/apm/mobile-services/{serviceName}/terms',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([
-      kueryRt,
-      rangeRt,
-      environmentRt,
-      t.type({
-        size: toNumberRt,
-        fieldName: t.string,
-      }),
-    ]),
+    query: z
+      .object({
+        size: z.coerce.number(),
+        fieldName: z.string(),
+      })
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_agent.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_agent.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { ServerlessType } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface ServiceAgentResponse {
   agentName?: string;
@@ -20,8 +20,8 @@ export interface ServiceAgentResponse {
 
 export const serviceAgentRoute = defineRoute<ServiceAgentResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/agent',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: rangeRt,
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema,
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_alerts_count.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_alerts_count.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export type ServiceAlertsResponse = Array<{
   serviceName: string;
@@ -18,8 +18,8 @@ export type ServiceAlertsCountRouteResponse = ServiceAlertsResponse[number];
 
 export const serviceAlertsCountRoute = defineRoute<ServiceAlertsCountRouteResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/alerts_count',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([rangeRt, environmentRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema.merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_annotations_search.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_annotations_search.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { Annotation } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface ServiceAnnotationResponse {
   annotations: Annotation[];
@@ -16,8 +16,8 @@ export interface ServiceAnnotationResponse {
 
 export const serviceAnnotationsSearchRoute = defineRoute<ServiceAnnotationResponse>()({
   endpoint: 'GET /api/apm/services/{serviceName}/annotation/search 2023-10-31',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([environmentRt, rangeRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: environmentSchema.merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_anomaly_charts.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_anomaly_charts.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { ServiceAnomalyTimeseries } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface ServiceAnomalyChartsResponse {
   allAnomalyTimeseries: ServiceAnomalyTimeseries[];
@@ -16,8 +16,8 @@ export interface ServiceAnomalyChartsResponse {
 
 export const serviceAnomalyChartsRoute = defineRoute<ServiceAnomalyChartsResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/anomaly_charts',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([rangeRt, environmentRt, t.type({ transactionType: t.string })]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema.merge(environmentSchema).merge(z.object({ transactionType: z.string() })),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_anomaly_score.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_anomaly_score.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { AnomalyDetectorType, Environment } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface ServiceAnomalyScoreResponse {
   anomalyScore?: number;
@@ -18,8 +18,8 @@ export interface ServiceAnomalyScoreResponse {
 
 export const serviceAnomalyScoreRoute = defineRoute<ServiceAnomalyScoreResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/anomaly_score',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([rangeRt, environmentRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema.merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_dependencies.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_dependencies.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { ConnectionStatsItemWithImpact } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, offsetRt } from '../../default_api_types';
+import { rangeSchema, offsetSchema } from '../../default_api_types';
 
 export type ServiceDependenciesResponse = Array<
   Omit<ConnectionStatsItemWithImpact, 'stats'> & {
@@ -24,8 +23,12 @@ export interface ServiceDependenciesRouteResponse {
 
 export const serviceDependenciesRoute = defineRoute<ServiceDependenciesRouteResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/dependencies',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([t.type({ numBuckets: toNumberRt }), environmentRt, rangeRt, offsetRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({ numBuckets: z.coerce.number() })
+      .merge(environmentSchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_dependencies_breakdown.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_dependencies_breakdown.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, kueryRt } from '../../default_api_types';
+import { rangeSchema, kuerySchema } from '../../default_api_types';
 
 export type ServiceDependenciesBreakdownResponse = Array<{
   title: string;
@@ -21,8 +21,8 @@ export interface ServiceDependenciesBreakdownRouteResponse {
 export const serviceDependenciesBreakdownRoute =
   defineRoute<ServiceDependenciesBreakdownRouteResponse>()({
     endpoint: 'GET /internal/apm/services/{serviceName}/dependencies/breakdown',
-    params: t.type({
-      path: t.type({ serviceName: t.string }),
-      query: t.intersection([environmentRt, rangeRt, kueryRt]),
+    params: z.object({
+      path: z.object({ serviceName: z.string() }),
+      query: environmentSchema.merge(rangeSchema).merge(kuerySchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_detailed_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_detailed_statistics.ts
@@ -4,13 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { Coordinate } from '@kbn/apm-types';
-import { latencyAggregationTypeRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { latencyAggregationTypeSchema } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface ServiceInstancesDetailedStat {
   serviceNodeName: string;
@@ -26,23 +25,36 @@ export interface ServiceInstancesDetailedStatisticsResponse {
   previousPeriod: Record<string, ServiceInstancesDetailedStat>;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value as an array of strings.
+const serviceNodeIdsSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const serviceInstancesDetailedStatisticsRoute =
   defineRoute<ServiceInstancesDetailedStatisticsResponse>()({
     endpoint:
       'GET /internal/apm/services/{serviceName}/service_overview_instances/detailed_statistics',
-    params: t.type({
-      path: t.type({ serviceName: t.string }),
-      query: t.intersection([
-        t.type({
-          latencyAggregationType: latencyAggregationTypeRt,
-          transactionType: t.string,
-          serviceNodeIds: jsonRt.pipe(t.array(t.string)),
-          numBuckets: toNumberRt,
-        }),
-        environmentRt,
-        kueryRt,
-        rangeRt,
-        offsetRt,
-      ]),
+    params: z.object({
+      path: z.object({ serviceName: z.string() }),
+      query: z
+        .object({
+          latencyAggregationType: latencyAggregationTypeSchema,
+          transactionType: z.string(),
+          serviceNodeIds: serviceNodeIdsSchema,
+          numBuckets: z.coerce.number(),
+        })
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema)
+        .merge(offsetSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_main_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_main_statistics.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { instancesSortFieldRt, latencyAggregationTypeRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { instancesSortFieldSchema, latencyAggregationTypeSchema } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export type ServiceInstanceMainStatisticsResponse = Array<{
   serviceNodeName: string;
@@ -27,19 +27,18 @@ export interface ServiceInstancesMainStatisticsRouteResponse {
 export const serviceInstancesMainStatisticsRoute =
   defineRoute<ServiceInstancesMainStatisticsRouteResponse>()({
     endpoint: 'GET /internal/apm/services/{serviceName}/service_overview_instances/main_statistics',
-    params: t.type({
-      path: t.type({ serviceName: t.string }),
-      query: t.intersection([
-        t.type({
-          latencyAggregationType: latencyAggregationTypeRt,
-          transactionType: t.string,
-          sortField: instancesSortFieldRt,
-          sortDirection: t.union([t.literal('asc'), t.literal('desc')]),
-        }),
-        offsetRt,
-        environmentRt,
-        kueryRt,
-        rangeRt,
-      ]),
+    params: z.object({
+      path: z.object({ serviceName: z.string() }),
+      query: z
+        .object({
+          latencyAggregationType: latencyAggregationTypeSchema,
+          transactionType: z.string(),
+          sortField: instancesSortFieldSchema,
+          sortDirection: z.union([z.literal('asc'), z.literal('desc')]),
+        })
+        .merge(offsetSchema)
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_metadata_details.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_instances_metadata_details.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { Agent, Service, Container, Kubernetes, Host, Cloud } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface ServiceInstanceMetadataDetailsResponse {
   '@timestamp': string;
@@ -32,11 +32,11 @@ export const serviceInstancesMetadataDetailsRoute =
   defineRoute<ServiceInstancesMetadataDetailsRouteResponse>()({
     endpoint:
       'GET /internal/apm/services/{serviceName}/service_overview_instances/details/{serviceNodeName}',
-    params: t.type({
-      path: t.type({
-        serviceName: t.string,
-        serviceNodeName: t.string,
+    params: z.object({
+      path: z.object({
+        serviceName: z.string(),
+        serviceNodeName: z.string(),
       }),
-      query: rangeRt,
+      query: rangeSchema,
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_metadata_details.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_metadata_details.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface ServiceMetadataDetails {
   service?: {
@@ -57,8 +57,8 @@ export interface ServiceMetadataDetails {
 
 export const serviceMetadataDetailsRoute = defineRoute<ServiceMetadataDetails>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/metadata/details',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([rangeRt, environmentRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema.merge(environmentSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_metadata_icons.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_metadata_icons.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { ContainerType, ServerlessType } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface ServiceMetadataIcons {
   agentName?: string;
@@ -18,8 +18,8 @@ export interface ServiceMetadataIcons {
 
 export const serviceMetadataIconsRoute = defineRoute<ServiceMetadataIcons>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/metadata/icons',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: rangeRt,
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema,
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_mixed_ingestion.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_mixed_ingestion.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { IngestionTimeRanges } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface ServiceMixedIngestionResponse {
   hasMultipleAgentTypes: boolean;
@@ -17,10 +17,10 @@ export interface ServiceMixedIngestionResponse {
 
 export const serviceMixedIngestionRoute = defineRoute<ServiceMixedIngestionResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/metrics/mixed_ingestion',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
     }),
-    query: t.intersection([environmentRt, kueryRt, rangeRt]),
+    query: environmentSchema.merge(kuerySchema).merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_node_metadata.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_node_metadata.ts
@@ -4,10 +4,14 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, serviceTransactionDataSourceRt } from '../../default_api_types';
+import {
+  kuerySchema,
+  rangeSchema,
+  serviceTransactionDataSourceSchema,
+} from '../../default_api_types';
 
 export interface ServiceNodeMetadataResponse {
   host: string | number;
@@ -16,11 +20,14 @@ export interface ServiceNodeMetadataResponse {
 
 export const serviceNodeMetadataRoute = defineRoute<ServiceNodeMetadataResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/node/{serviceNodeName}/metadata',
-  params: t.type({
-    path: t.type({
-      serviceName: t.string,
-      serviceNodeName: t.string,
+  params: z.object({
+    path: z.object({
+      serviceName: z.string(),
+      serviceNodeName: z.string(),
     }),
-    query: t.intersection([kueryRt, rangeRt, environmentRt, serviceTransactionDataSourceRt]),
+    query: kuerySchema
+      .merge(rangeSchema)
+      .merge(environmentSchema)
+      .merge(serviceTransactionDataSourceSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_slos.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_slos.ts
@@ -4,10 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { SLOWithSummaryResponse } from '@kbn/slo-schema';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
 
 export interface StatusCounts {
@@ -26,20 +25,38 @@ export interface ServiceSlosResponse {
   statusCounts: StatusCounts;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value is an array of strings.
+const statusFiltersJsonSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const serviceSlosRoute = defineRoute<ServiceSlosResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/slos',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      environmentRt,
-      t.type({
-        page: toNumberRt,
-        perPage: toNumberRt,
-      }),
-      t.partial({
-        statusFilters: jsonRt.pipe(t.array(t.string)),
-        kqlQuery: t.string,
-      }),
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: environmentSchema
+      .merge(
+        z.object({
+          page: z.coerce.number(),
+          perPage: z.coerce.number(),
+        })
+      )
+      .merge(
+        z
+          .object({
+            statusFilters: statusFiltersJsonSchema,
+            kqlQuery: z.string(),
+          })
+          .partial()
+      ),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_throughput.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_throughput.ts
@@ -4,17 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
 import {
-  kueryRt,
-  rangeRt,
-  offsetRt,
-  filtersRt,
-  serviceTransactionDataSourceRt,
+  kuerySchema,
+  rangeSchema,
+  offsetSchema,
+  filtersSchema,
+  serviceTransactionDataSourceSchema,
 } from '../../default_api_types';
 
 export type ServiceThroughputResponse = Coordinate[];
@@ -26,12 +25,23 @@ export interface ServiceThroughputRouteResponse {
 
 export const serviceThroughputRoute = defineRoute<ServiceThroughputRouteResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/throughput',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.type({ bucketSizeInSeconds: toNumberRt }),
-      t.partial({ transactionType: t.string, transactionName: t.string, filters: filtersRt }),
-      t.intersection([environmentRt, kueryRt, rangeRt, offsetRt, serviceTransactionDataSourceRt]),
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({ bucketSizeInSeconds: z.coerce.number() })
+      .merge(
+        z
+          .object({
+            transactionType: z.string(),
+            transactionName: z.string(),
+            filters: filtersSchema,
+          })
+          .partial()
+      )
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema)
+      .merge(serviceTransactionDataSourceSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_transaction_types.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/service_transaction_types.ts
@@ -4,9 +4,9 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { defineRoute } from '../types';
-import { rangeRt, serviceTransactionDataSourceRt } from '../../default_api_types';
+import { rangeSchema, serviceTransactionDataSourceSchema } from '../../default_api_types';
 
 export interface ServiceTransactionTypesResponse {
   transactionTypes: string[];
@@ -14,8 +14,8 @@ export interface ServiceTransactionTypesResponse {
 
 export const serviceTransactionTypesRoute = defineRoute<ServiceTransactionTypesResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/transaction_types',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([rangeRt, serviceTransactionDataSourceRt]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: rangeSchema.merge(serviceTransactionDataSourceSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_a_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_a_params.test.ts
@@ -1,0 +1,330 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { serviceAgentRoute } from './service_agent';
+import { serviceAlertsCountRoute } from './service_alerts_count';
+import { serviceAnnotationsSearchRoute } from './service_annotations_search';
+import { serviceAnomalyChartsRoute } from './service_anomaly_charts';
+import { serviceAnomalyScoreRoute } from './service_anomaly_score';
+import { serviceDependenciesBreakdownRoute } from './service_dependencies_breakdown';
+import { serviceDependenciesRoute } from './service_dependencies';
+import { serviceInstancesDetailedStatisticsRoute } from './service_instances_detailed_statistics';
+import { serviceInstancesMainStatisticsRoute } from './service_instances_main_statistics';
+import { serviceInstancesMetadataDetailsRoute } from './service_instances_metadata_details';
+
+describe('serviceAgentRoute params', () => {
+  it('accepts a valid path and range query', () => {
+    const result = serviceAgentRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    expectParseError(
+      serviceAgentRoute.params!.safeParse({
+        path: {},
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('serviceAlertsCountRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceAlertsCountRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing environment', () => {
+    expectParseError(
+      serviceAlertsCountRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('serviceAnnotationsSearchRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceAnnotationsSearchRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing range', () => {
+    expectParseError(
+      serviceAnnotationsSearchRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: { environment: 'production' },
+      })
+    );
+  });
+});
+
+describe('serviceAnomalyChartsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceAnomalyChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+        transactionType: 'request',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing transactionType', () => {
+    expectParseError(
+      serviceAnomalyChartsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          environment: 'production',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceAnomalyScoreRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceAnomalyScoreRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing path', () => {
+    expectParseError(
+      serviceAnomalyScoreRoute.params!.safeParse({
+        query: {
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          environment: 'production',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceDependenciesBreakdownRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceDependenciesBreakdownRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        kuery: '',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing kuery', () => {
+    expectParseError(
+      serviceDependenciesBreakdownRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          environment: 'production',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceDependenciesRoute params', () => {
+  it('accepts a valid path and query, coercing numBuckets', () => {
+    const result = serviceDependenciesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        numBuckets: '20',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an optional offset', () => {
+    const result = serviceDependenciesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        numBuckets: '20',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        offset: '1d',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing numBuckets', () => {
+    expectParseError(
+      serviceDependenciesRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          environment: 'production',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceInstancesDetailedStatisticsRoute params', () => {
+  it('accepts a valid path and query, parsing serviceNodeIds JSON', () => {
+    const result = serviceInstancesDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        latencyAggregationType: 'avg',
+        transactionType: 'request',
+        serviceNodeIds: JSON.stringify(['node-1', 'node-2']),
+        numBuckets: '20',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+    expect(result.data?.query.serviceNodeIds).toEqual(['node-1', 'node-2']);
+  });
+
+  it('rejects invalid JSON for serviceNodeIds', () => {
+    expectParseError(
+      serviceInstancesDetailedStatisticsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          latencyAggregationType: 'avg',
+          transactionType: 'request',
+          serviceNodeIds: '{not valid json',
+          numBuckets: '20',
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+
+  it('rejects an invalid latencyAggregationType', () => {
+    expectParseError(
+      serviceInstancesDetailedStatisticsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          latencyAggregationType: 'not-a-type',
+          transactionType: 'request',
+          serviceNodeIds: JSON.stringify(['node-1']),
+          numBuckets: '20',
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceInstancesMainStatisticsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceInstancesMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        latencyAggregationType: 'p95',
+        transactionType: 'request',
+        sortField: 'latency',
+        sortDirection: 'desc',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an invalid sortDirection', () => {
+    expectParseError(
+      serviceInstancesMainStatisticsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          latencyAggregationType: 'p95',
+          transactionType: 'request',
+          sortField: 'latency',
+          sortDirection: 'sideways',
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceInstancesMetadataDetailsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceInstancesMetadataDetailsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java', serviceNodeName: 'node-1' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceNodeName', () => {
+    expectParseError(
+      serviceInstancesMetadataDetailsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_b_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_b_params.test.ts
@@ -1,0 +1,342 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { serviceMetadataDetailsRoute } from './service_metadata_details';
+import { serviceMetadataIconsRoute } from './service_metadata_icons';
+import { serviceMixedIngestionRoute } from './service_mixed_ingestion';
+import { serviceNodeMetadataRoute } from './service_node_metadata';
+import { serviceSlosRoute } from './service_slos';
+import { serviceThroughputRoute } from './service_throughput';
+import { serviceTransactionTypesRoute } from './service_transaction_types';
+import { servicesDetailedStatisticsRoute } from './services_detailed_statistics';
+import { servicesListRoute } from './services_list';
+
+describe('serviceMetadataDetailsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceMetadataDetailsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    expectParseError(
+      serviceMetadataDetailsRoute.params!.safeParse({
+        path: {},
+        query: {
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          environment: 'production',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceMetadataIconsRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceMetadataIconsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing query', () => {
+    expectParseError(
+      serviceMetadataIconsRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {},
+      })
+    );
+  });
+});
+
+describe('serviceMixedIngestionRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceMixedIngestionRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+        kuery: '',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing kuery', () => {
+    expectParseError(
+      serviceMixedIngestionRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          environment: 'production',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceNodeMetadataRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceNodeMetadataRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java', serviceNodeName: 'instance-1' },
+      query: {
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        environment: 'production',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceNodeName', () => {
+    expectParseError(
+      serviceNodeMetadataRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          environment: 'production',
+          documentType: 'transactionMetric',
+          rollupInterval: '1m',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceSlosRoute params', () => {
+  it('accepts a valid path and query without optional fields', () => {
+    const result = serviceSlosRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: { environment: 'production', page: '1', perPage: '10' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts a valid statusFilters JSON string', () => {
+    const result = serviceSlosRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        page: '1',
+        perPage: '10',
+        statusFilters: JSON.stringify(['VIOLATED', 'HEALTHY']),
+        kqlQuery: 'foo: bar',
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.query.statusFilters).toEqual(['VIOLATED', 'HEALTHY']);
+    }
+  });
+
+  it('rejects an invalid statusFilters JSON string', () => {
+    expectParseError(
+      serviceSlosRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          environment: 'production',
+          page: '1',
+          perPage: '10',
+          statusFilters: 'not-json',
+        },
+      })
+    );
+  });
+
+  it('rejects a missing page', () => {
+    expectParseError(
+      serviceSlosRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: { environment: 'production', perPage: '10' },
+      })
+    );
+  });
+});
+
+describe('serviceThroughputRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceThroughputRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        bucketSizeInSeconds: '60',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing bucketSizeInSeconds', () => {
+    expectParseError(
+      serviceThroughputRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          documentType: 'transactionMetric',
+          rollupInterval: '1m',
+        },
+      })
+    );
+  });
+});
+
+describe('serviceTransactionTypesRoute params', () => {
+  it('accepts a valid path and query', () => {
+    const result = serviceTransactionTypesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing documentType', () => {
+    expectParseError(
+      serviceTransactionTypesRoute.params!.safeParse({
+        path: { serviceName: 'opbeans-java' },
+        query: {
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          rollupInterval: '1m',
+        },
+      })
+    );
+  });
+});
+
+describe('servicesDetailedStatisticsRoute params', () => {
+  it('accepts a valid query and body', () => {
+    const result = servicesDetailedStatisticsRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+        bucketSizeInSeconds: '60',
+        probability: '1',
+      },
+      body: { serviceNames: JSON.stringify(['opbeans-java', 'opbeans-node']) },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.body.serviceNames).toEqual(['opbeans-java', 'opbeans-node']);
+    }
+  });
+
+  it('rejects an invalid serviceNames JSON string', () => {
+    expectParseError(
+      servicesDetailedStatisticsRoute.params!.safeParse({
+        query: {
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          documentType: 'transactionMetric',
+          rollupInterval: '1m',
+          bucketSizeInSeconds: '60',
+          probability: '1',
+        },
+        body: { serviceNames: 'not-json' },
+      })
+    );
+  });
+});
+
+describe('servicesListRoute params', () => {
+  it('accepts a minimal valid query', () => {
+    const result = servicesListRoute.params!.safeParse({
+      query: {
+        probability: '1',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+        useDurationSummary: 'true',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.query.useDurationSummary).toBe(true);
+    }
+  });
+
+  it('accepts optional searchQuery/serviceGroup', () => {
+    const result = servicesListRoute.params!.safeParse({
+      query: {
+        searchQuery: 'foo',
+        serviceGroup: 'bar',
+        probability: '1',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+        useDurationSummary: 'false',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing useDurationSummary', () => {
+    expectParseError(
+      servicesListRoute.params!.safeParse({
+        query: {
+          probability: '1',
+          documentType: 'transactionMetric',
+          rollupInterval: '1m',
+          environment: 'production',
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_detailed_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_detailed_statistics.ts
@@ -4,17 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
 import {
-  kueryRt,
-  rangeRt,
-  offsetRt,
-  probabilityRt,
-  serviceTransactionDataSourceRt,
+  kuerySchema,
+  rangeSchema,
+  offsetSchema,
+  probabilitySchema,
+  serviceTransactionDataSourceSchema,
 } from '../../default_api_types';
 
 export interface ServiceTransactionDetailedStat {
@@ -29,19 +28,35 @@ export interface ServiceTransactionDetailedStatPeriodsResponse {
   previousPeriod: Record<string, ServiceTransactionDetailedStat>;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value is an array of strings.
+const serviceNamesJsonSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const servicesDetailedStatisticsRoute =
   defineRoute<ServiceTransactionDetailedStatPeriodsResponse>()({
     endpoint: 'POST /internal/apm/services/detailed_statistics',
-    params: t.type({
-      query: t.intersection([
-        environmentRt,
-        kueryRt,
-        rangeRt,
-        t.intersection([offsetRt, probabilityRt, serviceTransactionDataSourceRt]),
-        t.type({
-          bucketSizeInSeconds: toNumberRt,
-        }),
-      ]),
-      body: t.type({ serviceNames: jsonRt.pipe(t.array(t.string)) }),
+    params: z.object({
+      query: environmentSchema
+        .merge(kuerySchema)
+        .merge(rangeSchema)
+        .merge(offsetSchema)
+        .merge(probabilitySchema)
+        .merge(serviceTransactionDataSourceSchema)
+        .merge(
+          z.object({
+            bucketSizeInSeconds: z.coerce.number(),
+          })
+        ),
+      body: z.object({ serviceNames: serviceNamesJsonSchema }),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_list.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/services/services_list.ts
@@ -4,17 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toBooleanRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
 import type { AgentName } from '@kbn/elastic-agent-utils';
 import type { AnomalyDetectorType, Environment, SloStatus } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
 import {
-  kueryRt,
-  rangeRt,
-  probabilityRt,
-  serviceTransactionDataSourceRt,
+  kuerySchema,
+  rangeSchema,
+  probabilitySchema,
+  serviceTransactionDataSourceSchema,
 } from '../../default_api_types';
 
 export interface MergedServiceStat {
@@ -41,24 +41,22 @@ export interface ServicesItemsResponse {
 
 export const servicesListRoute = defineRoute<ServicesItemsResponse>()({
   endpoint: 'GET /internal/apm/services',
-  params: t.type({
-    query: t.intersection([
-      t.partial({
-        searchQuery: t.string,
-        serviceGroup: t.string,
-      }),
-      t.intersection([
-        probabilityRt,
-        t.intersection([
-          serviceTransactionDataSourceRt,
-          t.type({
-            useDurationSummary: toBooleanRt,
-          }),
-        ]),
-        environmentRt,
-        kueryRt,
-        rangeRt,
-      ]),
-    ]),
+  params: z.object({
+    query: z
+      .object({
+        searchQuery: z.string(),
+        serviceGroup: z.string(),
+      })
+      .partial()
+      .merge(probabilitySchema)
+      .merge(serviceTransactionDataSourceSchema)
+      .merge(
+        z.object({
+          useDurationSummary: BooleanFromString,
+        })
+      )
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/root_transaction_by_trace_id.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/root_transaction_by_trace_id.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { TransactionDetailRedirectInfo } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface RootTransactionByTraceIdResponse {
   transaction?: TransactionDetailRedirectInfo;
@@ -15,10 +15,10 @@ export interface RootTransactionByTraceIdResponse {
 
 export const rootTransactionByTraceIdRoute = defineRoute<RootTransactionByTraceIdResponse>()({
   endpoint: 'GET /internal/apm/traces/{traceId}/root_transaction',
-  params: t.type({
-    path: t.type({
-      traceId: t.string,
+  params: z.object({
+    path: z.object({
+      traceId: z.string(),
     }),
-    query: rangeRt,
+    query: rangeSchema,
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/span_from_trace_by_id.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/span_from_trace_by_id.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { Span, Transaction } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface SpanFromTraceByIdResponse {
   span?: Span;
@@ -16,14 +16,11 @@ export interface SpanFromTraceByIdResponse {
 
 export const spanFromTraceByIdRoute = defineRoute<SpanFromTraceByIdResponse>()({
   endpoint: 'GET /internal/apm/traces/{traceId}/spans/{spanId}',
-  params: t.type({
-    path: t.type({
-      traceId: t.string,
-      spanId: t.string,
+  params: z.object({
+    path: z.object({
+      traceId: z.string(),
+      spanId: z.string(),
     }),
-    query: t.intersection([
-      rangeRt,
-      t.union([t.partial({ parentTransactionId: t.string }), t.undefined]),
-    ]),
+    query: rangeSchema.merge(z.object({ parentTransactionId: z.string().optional() })),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/traces.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/traces.ts
@@ -4,12 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { type AgentName } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { type AgentName, environmentSchema } from '@kbn/apm-types';
 import type { TRANSACTION_NAME, SERVICE_NAME } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, probabilityRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, probabilitySchema } from '../../default_api_types';
 
 export type BucketKey = Record<typeof TRANSACTION_NAME | typeof SERVICE_NAME, string>;
 
@@ -28,7 +27,7 @@ export interface TopTracesPrimaryStatsResponse {
 
 export const tracesRoute = defineRoute<TopTracesPrimaryStatsResponse>()({
   endpoint: 'GET /internal/apm/traces',
-  params: t.type({
-    query: t.intersection([environmentRt, kueryRt, rangeRt, probabilityRt]),
+  params: z.object({
+    query: environmentSchema.merge(kuerySchema).merge(rangeSchema).merge(probabilitySchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/traces_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/traces_params.test.ts
@@ -1,0 +1,334 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { rootTransactionByTraceIdRoute } from './root_transaction_by_trace_id';
+import { spanFromTraceByIdRoute } from './span_from_trace_by_id';
+import { tracesRoute } from './traces';
+import { transactionByIdRoute } from './transaction_by_id';
+import { transactionByNameRoute } from './transaction_by_name';
+import { transactionFromTraceByIdRoute } from './transaction_from_trace_by_id';
+import { unifiedTraceSpanRoute } from './unified_trace_span';
+import { unifiedTracesByIdErrorsRoute } from './unified_traces_by_id_errors';
+import { unifiedTracesByIdSummaryRoute } from './unified_traces_by_id_summary';
+import { unifiedTracesByIdRoute } from './unified_traces_by_id';
+import { unifiedTracesRootSpanRoute } from './unified_traces_root_span';
+
+describe('rootTransactionByTraceIdRoute params', () => {
+  it('accepts a traceId and range query', () => {
+    const result = rootTransactionByTraceIdRoute.params!.safeParse({
+      path: { traceId: 'abc' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing traceId', () => {
+    expectParseError(
+      rootTransactionByTraceIdRoute.params!.safeParse({
+        path: {},
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('spanFromTraceByIdRoute params', () => {
+  it('accepts a traceId/spanId and range query', () => {
+    const result = spanFromTraceByIdRoute.params!.safeParse({
+      path: { traceId: 'abc', spanId: 'def' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an optional parentTransactionId', () => {
+    const result = spanFromTraceByIdRoute.params!.safeParse({
+      path: { traceId: 'abc', spanId: 'def' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        parentTransactionId: 'ghi',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing spanId', () => {
+    expectParseError(
+      spanFromTraceByIdRoute.params!.safeParse({
+        path: { traceId: 'abc' },
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('tracesRoute params', () => {
+  it('accepts environment/kuery/range/probability query', () => {
+    const result = tracesRoute.params!.safeParse({
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        probability: '0.5',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing environment', () => {
+    expectParseError(
+      tracesRoute.params!.safeParse({
+        query: {
+          kuery: '',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          probability: '0.5',
+        },
+      })
+    );
+  });
+});
+
+describe('transactionByIdRoute params', () => {
+  it('accepts a transactionId and range query', () => {
+    const result = transactionByIdRoute.params!.safeParse({
+      path: { transactionId: 'abc' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing transactionId', () => {
+    expectParseError(
+      transactionByIdRoute.params!.safeParse({
+        path: {},
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('transactionByNameRoute params', () => {
+  it('accepts transactionName/serviceName and range query', () => {
+    const result = transactionByNameRoute.params!.safeParse({
+      query: {
+        transactionName: 'GET /api',
+        serviceName: 'opbeans-java',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an optional environment', () => {
+    const result = transactionByNameRoute.params!.safeParse({
+      query: {
+        transactionName: 'GET /api',
+        serviceName: 'opbeans-java',
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing serviceName', () => {
+    expectParseError(
+      transactionByNameRoute.params!.safeParse({
+        query: {
+          transactionName: 'GET /api',
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+        },
+      })
+    );
+  });
+});
+
+describe('transactionFromTraceByIdRoute params', () => {
+  it('accepts a traceId/transactionId and range query', () => {
+    const result = transactionFromTraceByIdRoute.params!.safeParse({
+      path: { traceId: 'abc', transactionId: 'def' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing transactionId', () => {
+    expectParseError(
+      transactionFromTraceByIdRoute.params!.safeParse({
+        path: { traceId: 'abc' },
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('unifiedTraceSpanRoute params', () => {
+  it('accepts a traceId/spanId and range query', () => {
+    const result = unifiedTraceSpanRoute.params!.safeParse({
+      path: { traceId: 'abc', spanId: 'def' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing traceId', () => {
+    expectParseError(
+      unifiedTraceSpanRoute.params!.safeParse({
+        path: { spanId: 'def' },
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('unifiedTracesByIdErrorsRoute params', () => {
+  it('accepts a traceId and range query', () => {
+    const result = unifiedTracesByIdErrorsRoute.params!.safeParse({
+      path: { traceId: 'abc' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts an optional docId', () => {
+    const result = unifiedTracesByIdErrorsRoute.params!.safeParse({
+      path: { traceId: 'abc' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        docId: 'doc-1',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing traceId', () => {
+    expectParseError(
+      unifiedTracesByIdErrorsRoute.params!.safeParse({
+        path: {},
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('unifiedTracesByIdSummaryRoute params', () => {
+  it('accepts a traceId and range query', () => {
+    const result = unifiedTracesByIdSummaryRoute.params!.safeParse({
+      path: { traceId: 'abc' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts optional maxTraceItems/docId and coerces maxTraceItems to a number', () => {
+    const result = unifiedTracesByIdSummaryRoute.params!.safeParse({
+      path: { traceId: 'abc' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        maxTraceItems: '500',
+        docId: 'doc-1',
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.query.maxTraceItems).toBe(500);
+    }
+  });
+
+  it('rejects a missing traceId', () => {
+    expectParseError(
+      unifiedTracesByIdSummaryRoute.params!.safeParse({
+        path: {},
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});
+
+describe('unifiedTracesByIdRoute params', () => {
+  it('accepts a traceId and range query', () => {
+    const result = unifiedTracesByIdRoute.params!.safeParse({
+      path: { traceId: 'abc' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts optional serviceName/entryTransactionId/ecsOnly and coerces ecsOnly to a boolean', () => {
+    const result = unifiedTracesByIdRoute.params!.safeParse({
+      path: { traceId: 'abc' },
+      query: {
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        serviceName: 'opbeans-java',
+        entryTransactionId: 'def',
+        ecsOnly: 'true',
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.query.ecsOnly).toBe(true);
+    }
+  });
+
+  it('rejects an invalid ecsOnly value', () => {
+    expectParseError(
+      unifiedTracesByIdRoute.params!.safeParse({
+        path: { traceId: 'abc' },
+        query: {
+          start: '2021-01-01T00:00:00.000Z',
+          end: '2021-01-02T00:00:00.000Z',
+          ecsOnly: 'not-a-boolean',
+        },
+      })
+    );
+  });
+});
+
+describe('unifiedTracesRootSpanRoute params', () => {
+  it('accepts a traceId and range query', () => {
+    const result = unifiedTracesRootSpanRoute.params!.safeParse({
+      path: { traceId: 'abc' },
+      query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing traceId', () => {
+    expectParseError(
+      unifiedTracesRootSpanRoute.params!.safeParse({
+        path: {},
+        query: { start: '2021-01-01T00:00:00.000Z', end: '2021-01-02T00:00:00.000Z' },
+      })
+    );
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_by_id.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_by_id.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { Transaction } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface TransactionByIdResponse {
   transaction?: Transaction;
@@ -15,10 +15,10 @@ export interface TransactionByIdResponse {
 
 export const transactionByIdRoute = defineRoute<TransactionByIdResponse>()({
   endpoint: 'GET /internal/apm/transactions/{transactionId}',
-  params: t.type({
-    path: t.type({
-      transactionId: t.string,
+  params: z.object({
+    path: z.object({
+      transactionId: z.string(),
     }),
-    query: rangeRt,
+    query: rangeSchema,
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_by_name.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_by_name.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { TransactionDetailRedirectInfo } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface TransactionByNameResponse {
   transaction?: TransactionDetailRedirectInfo;
@@ -15,16 +15,18 @@ export interface TransactionByNameResponse {
 
 export const transactionByNameRoute = defineRoute<TransactionByNameResponse>()({
   endpoint: 'GET /internal/apm/transactions',
-  params: t.type({
-    query: t.intersection([
-      rangeRt,
-      t.type({
-        transactionName: t.string,
-        serviceName: t.string,
-      }),
-      t.partial({
-        environment: t.string,
-      }),
-    ]),
+  params: z.object({
+    query: rangeSchema
+      .merge(
+        z.object({
+          transactionName: z.string(),
+          serviceName: z.string(),
+        })
+      )
+      .merge(
+        z.object({
+          environment: z.string().optional(),
+        })
+      ),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_from_trace_by_id.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/transaction_from_trace_by_id.ts
@@ -4,20 +4,20 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { Transaction } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export type TransactionFromTraceByIdResponse = Transaction;
 
 export const transactionFromTraceByIdRoute = defineRoute<TransactionFromTraceByIdResponse>()({
   endpoint: 'GET /internal/apm/traces/{traceId}/transactions/{transactionId}',
-  params: t.type({
-    path: t.type({
-      traceId: t.string,
-      transactionId: t.string,
+  params: z.object({
+    path: z.object({
+      traceId: z.string(),
+      transactionId: z.string(),
     }),
-    query: rangeRt,
+    query: rangeSchema,
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_trace_span.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_trace_span.ts
@@ -4,20 +4,20 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { UnifiedSpanDocument } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export type UnifiedTraceSpanResponse = UnifiedSpanDocument;
 
 export const unifiedTraceSpanRoute = defineRoute<UnifiedTraceSpanResponse>()({
   endpoint: 'GET /internal/apm/unified_traces/{traceId}/spans/{spanId}',
-  params: t.type({
-    path: t.type({
-      traceId: t.string,
-      spanId: t.string,
+  params: z.object({
+    path: z.object({
+      traceId: z.string(),
+      spanId: z.string(),
     }),
-    query: rangeRt,
+    query: rangeSchema,
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toBooleanRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
 import type { Error as ApmError, TraceItem, Transaction } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface UnifiedTracesByIdResponse {
   traceItems: TraceItem[];
@@ -21,17 +21,16 @@ export interface UnifiedTracesByIdResponse {
 
 export const unifiedTracesByIdRoute = defineRoute<UnifiedTracesByIdResponse>()({
   endpoint: 'GET /internal/apm/unified_traces/{traceId}',
-  params: t.type({
-    path: t.type({
-      traceId: t.string,
+  params: z.object({
+    path: z.object({
+      traceId: z.string(),
     }),
-    query: t.intersection([
-      rangeRt,
-      t.partial({
-        serviceName: t.string,
-        entryTransactionId: t.string,
-        ecsOnly: toBooleanRt,
-      }),
-    ]),
+    query: rangeSchema.merge(
+      z.object({
+        serviceName: z.string().optional(),
+        entryTransactionId: z.string().optional(),
+        ecsOnly: BooleanFromString.optional(),
+      })
+    ),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id_errors.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id_errors.ts
@@ -4,17 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { ErrorsByTraceId } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export const unifiedTracesByIdErrorsRoute = defineRoute<ErrorsByTraceId>()({
   endpoint: 'GET /internal/apm/unified_traces/{traceId}/errors',
-  params: t.type({
-    path: t.type({
-      traceId: t.string,
+  params: z.object({
+    path: z.object({
+      traceId: z.string(),
     }),
-    query: t.intersection([rangeRt, t.partial({ docId: t.string })]),
+    query: rangeSchema.merge(z.object({ docId: z.string().optional() })),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id_summary.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_by_id_summary.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import type { FocusedTraceItems } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export interface UnifiedTracesByIdSummaryResponse {
   traceItems?: FocusedTraceItems;
@@ -17,10 +16,15 @@ export interface UnifiedTracesByIdSummaryResponse {
 
 export const unifiedTracesByIdSummaryRoute = defineRoute<UnifiedTracesByIdSummaryResponse>()({
   endpoint: 'GET /internal/apm/unified_traces/{traceId}/summary',
-  params: t.type({
-    path: t.type({
-      traceId: t.string,
+  params: z.object({
+    path: z.object({
+      traceId: z.string(),
     }),
-    query: t.intersection([rangeRt, t.partial({ maxTraceItems: toNumberRt, docId: t.string })]),
+    query: rangeSchema.merge(
+      z.object({
+        maxTraceItems: z.coerce.number().optional(),
+        docId: z.string().optional(),
+      })
+    ),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_root_span.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/traces/unified_traces_root_span.ts
@@ -4,19 +4,19 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import type { TraceRootSpan } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt } from '../../default_api_types';
+import { rangeSchema } from '../../default_api_types';
 
 export type UnifiedTracesRootSpanResponse = TraceRootSpan;
 
 export const unifiedTracesRootSpanRoute = defineRoute<UnifiedTracesRootSpanResponse>()({
   endpoint: 'GET /internal/apm/unified_traces/{traceId}/root_span',
-  params: t.type({
-    path: t.type({
-      traceId: t.string,
+  params: z.object({
+    path: z.object({
+      traceId: z.string(),
     }),
-    query: rangeRt,
+    query: rangeSchema,
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/breakdown.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/breakdown.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface TransactionBreakdownResponse {
   timeseries: Array<{
@@ -21,14 +21,13 @@ export interface TransactionBreakdownResponse {
 
 export const transactionChartsBreakdownRoute = defineRoute<TransactionBreakdownResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/transaction/charts/breakdown',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.type({ transactionType: t.string }),
-      t.partial({ transactionName: t.string }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({ transactionType: z.string() })
+      .merge(z.object({ transactionName: z.string() }).partial())
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/coldstart_rate.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/coldstart_rate.ts
@@ -4,11 +4,11 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 
 export interface ColdstartRateResponse {
   currentPeriod: {
@@ -23,11 +23,13 @@ export interface ColdstartRateResponse {
 
 export const transactionChartsColdstartRateRoute = defineRoute<ColdstartRateResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/transactions/charts/coldstart_rate',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.type({ transactionType: t.string }),
-      t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({ transactionType: z.string() })
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/coldstart_rate_by_transaction_name.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/coldstart_rate_by_transaction_name.ts
@@ -4,10 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema, offsetSchema } from '../../default_api_types';
 import type { ColdstartRateResponse } from './coldstart_rate';
 
 export type ColdstartRateByTransactionNameResponse = ColdstartRateResponse;
@@ -16,11 +16,13 @@ export const transactionChartsColdstartRateByTransactionNameRoute =
   defineRoute<ColdstartRateByTransactionNameResponse>()({
     endpoint:
       'GET /internal/apm/services/{serviceName}/transactions/charts/coldstart_rate_by_transaction_name',
-    params: t.type({
-      path: t.type({ serviceName: t.string }),
-      query: t.intersection([
-        t.type({ transactionType: t.string, transactionName: t.string }),
-        t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
-      ]),
+    params: z.object({
+      path: z.object({ serviceName: z.string() }),
+      query: z
+        .object({ transactionType: z.string(), transactionName: z.string() })
+        .merge(environmentSchema)
+        .merge(kuerySchema)
+        .merge(rangeSchema)
+        .merge(offsetSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/error_rate.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/error_rate.ts
@@ -4,17 +4,16 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
 import { type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
 import {
-  kueryRt,
-  rangeRt,
-  offsetRt,
-  filtersRt,
-  serviceTransactionDataSourceRt,
+  kuerySchema,
+  rangeSchema,
+  offsetSchema,
+  filtersSchema,
+  serviceTransactionDataSourceSchema,
 } from '../../default_api_types';
 
 export interface FailedTransactionRateResponse {
@@ -30,12 +29,15 @@ export interface FailedTransactionRateResponse {
 
 export const transactionChartsErrorRateRoute = defineRoute<FailedTransactionRateResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/transactions/charts/error_rate',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.type({ transactionType: t.string, bucketSizeInSeconds: toNumberRt }),
-      t.partial({ transactionName: t.string, filters: filtersRt }),
-      t.intersection([environmentRt, kueryRt, rangeRt, offsetRt, serviceTransactionDataSourceRt]),
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({ transactionType: z.string(), bucketSizeInSeconds: z.coerce.number() })
+      .merge(z.object({ transactionName: z.string(), filters: filtersSchema }).partial())
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema)
+      .merge(serviceTransactionDataSourceSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/groups_detailed_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/groups_detailed_statistics.ts
@@ -4,12 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { jsonRt, toBooleanRt, toNumberRt } from '@kbn/io-ts-utils';
-import { latencyAggregationTypeRt, type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
+import { latencyAggregationTypeSchema, type Coordinate } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt, offsetRt, transactionDataSourceRt } from '../../default_api_types';
+import {
+  kuerySchema,
+  rangeSchema,
+  offsetSchema,
+  transactionDataSourceSchema,
+} from '../../default_api_types';
 
 export interface ServiceTransactionGroupDetailedStat {
   transactionName: string;
@@ -24,28 +29,42 @@ export interface ServiceTransactionGroupDetailedStatisticsResponse {
   previousPeriod: Record<string, ServiceTransactionGroupDetailedStat>;
 }
 
+// Equivalent of io-ts's jsonRt.pipe(t.array(t.string)): parse a JSON string,
+// then validate the parsed value as an array of strings.
+const transactionNamesSchema = z
+  .string()
+  .transform((value, ctx) => {
+    try {
+      return JSON.parse(value);
+    } catch (err) {
+      ctx.addIssue({ code: 'custom', message: err.message });
+      return z.NEVER;
+    }
+  })
+  .pipe(z.array(z.string()));
+
 export const transactionGroupsDetailedStatisticsRoute =
   defineRoute<ServiceTransactionGroupDetailedStatisticsResponse>()({
     endpoint: 'GET /internal/apm/services/{serviceName}/transactions/groups/detailed_statistics',
-    params: t.type({
-      path: t.type({ serviceName: t.string }),
-      query: t.intersection([
-        environmentRt,
-        kueryRt,
-        rangeRt,
-        t.intersection([
-          offsetRt,
-          transactionDataSourceRt,
-          t.type({
-            bucketSizeInSeconds: toNumberRt,
-            useDurationSummary: toBooleanRt,
-          }),
-        ]),
-        t.type({
-          transactionNames: jsonRt.pipe(t.array(t.string)),
-          transactionType: t.string,
-          latencyAggregationType: latencyAggregationTypeRt,
-        }),
-      ]),
+    params: z.object({
+      path: z.object({ serviceName: z.string() }),
+      query: environmentSchema
+        .merge(kuerySchema)
+        .merge(rangeSchema)
+        .merge(offsetSchema)
+        .merge(transactionDataSourceSchema)
+        .merge(
+          z.object({
+            bucketSizeInSeconds: z.coerce.number(),
+            useDurationSummary: BooleanFromString,
+          })
+        )
+        .merge(
+          z.object({
+            transactionNames: transactionNamesSchema,
+            transactionType: z.string(),
+            latencyAggregationType: latencyAggregationTypeSchema,
+          })
+        ),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/groups_main_statistics.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/groups_main_statistics.ts
@@ -4,12 +4,12 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toBooleanRt } from '@kbn/io-ts-utils';
-import { latencyAggregationTypeRt } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
+import { latencyAggregationTypeSchema } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { rangeRt, transactionDataSourceRt } from '../../default_api_types';
+import { rangeSchema, transactionDataSourceSchema } from '../../default_api_types';
 
 export interface MergedServiceTransactionGroupsResponse {
   transactionGroups: Array<{
@@ -29,19 +29,21 @@ export interface MergedServiceTransactionGroupsResponse {
 export const transactionGroupsMainStatisticsRoute =
   defineRoute<MergedServiceTransactionGroupsResponse>()({
     endpoint: 'GET /internal/apm/services/{serviceName}/transactions/groups/main_statistics',
-    params: t.type({
-      path: t.type({ serviceName: t.string }),
-      query: t.intersection([
-        t.partial({ searchQuery: t.string }),
-        environmentRt,
-        rangeRt,
-        t.type({
-          kuery: t.string,
-          useDurationSummary: toBooleanRt,
-          transactionType: t.string,
-          latencyAggregationType: latencyAggregationTypeRt,
-        }),
-        transactionDataSourceRt,
-      ]),
+    params: z.object({
+      path: z.object({ serviceName: z.string() }),
+      query: z
+        .object({ searchQuery: z.string() })
+        .partial()
+        .merge(environmentSchema)
+        .merge(rangeSchema)
+        .merge(
+          z.object({
+            kuery: z.string(),
+            useDurationSummary: BooleanFromString,
+            transactionType: z.string(),
+            latencyAggregationType: latencyAggregationTypeSchema,
+          })
+        )
+        .merge(transactionDataSourceSchema),
     }),
   });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/latency_charts.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/latency_charts.ts
@@ -4,17 +4,17 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toBooleanRt, toNumberRt } from '@kbn/io-ts-utils';
-import { latencyAggregationTypeRt, type Coordinate } from '@kbn/apm-types';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
+import { latencyAggregationTypeSchema, type Coordinate } from '@kbn/apm-types';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
 import {
-  kueryRt,
-  rangeRt,
-  offsetRt,
-  filtersRt,
-  serviceTransactionDataSourceRt,
+  kuerySchema,
+  rangeSchema,
+  offsetSchema,
+  filtersSchema,
+  serviceTransactionDataSourceSchema,
 } from '../../default_api_types';
 
 export interface TransactionLatencyResponse {
@@ -30,17 +30,27 @@ export interface TransactionLatencyResponse {
 
 export const transactionLatencyChartsRoute = defineRoute<TransactionLatencyResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/transactions/charts/latency',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.type({
-        latencyAggregationType: latencyAggregationTypeRt,
-        bucketSizeInSeconds: toNumberRt,
-        useDurationSummary: toBooleanRt,
-      }),
-      t.partial({ transactionType: t.string, transactionName: t.string, filters: filtersRt }),
-      t.intersection([environmentRt, kueryRt, rangeRt, offsetRt]),
-      serviceTransactionDataSourceRt,
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({
+        latencyAggregationType: latencyAggregationTypeSchema,
+        bucketSizeInSeconds: z.coerce.number(),
+        useDurationSummary: BooleanFromString,
+      })
+      .merge(
+        z
+          .object({
+            transactionType: z.string(),
+            transactionName: z.string(),
+            filters: filtersSchema,
+          })
+          .partial()
+      )
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema)
+      .merge(offsetSchema)
+      .merge(serviceTransactionDataSourceSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/trace_samples.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/trace_samples.ts
@@ -4,11 +4,10 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { toNumberRt } from '@kbn/io-ts-utils';
-import { environmentRt } from '@kbn/apm-types';
+import { z } from '@kbn/zod/v4';
+import { environmentSchema } from '@kbn/apm-types';
 import { defineRoute } from '../types';
-import { kueryRt, rangeRt } from '../../default_api_types';
+import { kuerySchema, rangeSchema } from '../../default_api_types';
 
 export interface TransactionTraceSamplesResponse {
   traceSamples: Array<{
@@ -21,19 +20,22 @@ export interface TransactionTraceSamplesResponse {
 
 export const transactionTraceSamplesRoute = defineRoute<TransactionTraceSamplesResponse>()({
   endpoint: 'GET /internal/apm/services/{serviceName}/transactions/traces/samples',
-  params: t.type({
-    path: t.type({ serviceName: t.string }),
-    query: t.intersection([
-      t.type({ transactionType: t.string, transactionName: t.string }),
-      t.partial({
-        transactionId: t.string,
-        traceId: t.string,
-        sampleRangeFrom: toNumberRt,
-        sampleRangeTo: toNumberRt,
-      }),
-      environmentRt,
-      kueryRt,
-      rangeRt,
-    ]),
+  params: z.object({
+    path: z.object({ serviceName: z.string() }),
+    query: z
+      .object({ transactionType: z.string(), transactionName: z.string() })
+      .merge(
+        z
+          .object({
+            transactionId: z.string(),
+            traceId: z.string(),
+            sampleRangeFrom: z.coerce.number(),
+            sampleRangeTo: z.coerce.number(),
+          })
+          .partial()
+      )
+      .merge(environmentSchema)
+      .merge(kuerySchema)
+      .merge(rangeSchema),
   }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/transactions_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/transactions/transactions_params.test.ts
@@ -1,0 +1,336 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { transactionChartsBreakdownRoute } from './breakdown';
+import { transactionChartsColdstartRateByTransactionNameRoute } from './coldstart_rate_by_transaction_name';
+import { transactionChartsColdstartRateRoute } from './coldstart_rate';
+import { transactionChartsErrorRateRoute } from './error_rate';
+import { transactionGroupsDetailedStatisticsRoute } from './groups_detailed_statistics';
+import { transactionGroupsMainStatisticsRoute } from './groups_main_statistics';
+import { transactionLatencyChartsRoute } from './latency_charts';
+import { transactionTraceSamplesRoute } from './trace_samples';
+
+describe('transactionChartsBreakdownRoute params', () => {
+  it('accepts a valid query without the optional transactionName', () => {
+    const result = transactionChartsBreakdownRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing transactionType', () => {
+    const result = transactionChartsBreakdownRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('transactionChartsColdstartRateRoute params', () => {
+  it('accepts a valid query with an optional offset', () => {
+    const result = transactionChartsColdstartRateRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        offset: '1d',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a missing path param', () => {
+    const result = transactionChartsColdstartRateRoute.params!.safeParse({
+      path: {},
+      query: {
+        transactionType: 'request',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('transactionChartsColdstartRateByTransactionNameRoute params', () => {
+  it('accepts a valid query', () => {
+    const result = transactionChartsColdstartRateByTransactionNameRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        transactionName: 'GET /api',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing transactionName', () => {
+    const result = transactionChartsColdstartRateByTransactionNameRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('transactionChartsErrorRateRoute params', () => {
+  it('accepts a valid query and coerces bucketSizeInSeconds', () => {
+    const result = transactionChartsErrorRateRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        bucketSizeInSeconds: '60',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.query.bucketSizeInSeconds).toBe(60);
+    }
+  });
+
+  it('rejects an invalid bucketSizeInSeconds', () => {
+    const result = transactionChartsErrorRateRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        bucketSizeInSeconds: 'not-a-number',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('transactionGroupsDetailedStatisticsRoute params', () => {
+  it('accepts a valid query and parses transactionNames JSON', () => {
+    const result = transactionGroupsDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+        bucketSizeInSeconds: '60',
+        useDurationSummary: 'true',
+        transactionNames: JSON.stringify(['GET /api', 'POST /api']),
+        transactionType: 'request',
+        latencyAggregationType: 'avg',
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.query.transactionNames).toEqual(['GET /api', 'POST /api']);
+      expect(result.data.query.useDurationSummary).toBe(true);
+    }
+  });
+
+  it('rejects a transactionNames value that is not valid JSON', () => {
+    const result = transactionGroupsDetailedStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+        bucketSizeInSeconds: '60',
+        useDurationSummary: 'true',
+        transactionNames: 'not-json',
+        transactionType: 'request',
+        latencyAggregationType: 'avg',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('transactionGroupsMainStatisticsRoute params', () => {
+  it('accepts a valid query without the optional searchQuery', () => {
+    const result = transactionGroupsMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        kuery: '',
+        useDurationSummary: 'false',
+        transactionType: 'request',
+        latencyAggregationType: 'p95',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a query missing kuery', () => {
+    const result = transactionGroupsMainStatisticsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        environment: 'production',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        useDurationSummary: 'false',
+        transactionType: 'request',
+        latencyAggregationType: 'p95',
+        documentType: 'transactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('transactionLatencyChartsRoute params', () => {
+  it('accepts a valid query without the optional transactionType/transactionName/filters', () => {
+    const result = transactionLatencyChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        latencyAggregationType: 'avg',
+        bucketSizeInSeconds: '60',
+        useDurationSummary: 'true',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'serviceTransactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects an invalid latencyAggregationType', () => {
+    const result = transactionLatencyChartsRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        latencyAggregationType: 'not-a-valid-type',
+        bucketSizeInSeconds: '60',
+        useDurationSummary: 'true',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        documentType: 'serviceTransactionMetric',
+        rollupInterval: '1m',
+      },
+    });
+
+    expectParseError(result);
+  });
+});
+
+describe('transactionTraceSamplesRoute params', () => {
+  it('accepts a valid query without the optional fields', () => {
+    const result = transactionTraceSamplesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        transactionName: 'GET /api',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('accepts optional sampleRangeFrom/sampleRangeTo and coerces them', () => {
+    const result = transactionTraceSamplesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        transactionName: 'GET /api',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+        sampleRangeFrom: '0',
+        sampleRangeTo: '1000',
+      },
+    });
+
+    expectParseSuccess(result);
+    if (result.success) {
+      expect(result.data.query.sampleRangeFrom).toBe(0);
+      expect(result.data.query.sampleRangeTo).toBe(1000);
+    }
+  });
+
+  it('rejects a query missing transactionName', () => {
+    const result = transactionTraceSamplesRoute.params!.safeParse({
+      path: { serviceName: 'opbeans-java' },
+      query: {
+        transactionType: 'request',
+        environment: 'production',
+        kuery: '',
+        start: '2021-01-01T00:00:00.000Z',
+        end: '2021-01-02T00:00:00.000Z',
+      },
+    });
+
+    expectParseError(result);
+  });
+});


### PR DESCRIPTION
## Summary

Part of the `io-ts` -> `@kbn/zod` migration tracked in elastic/kibana#243355.

This completes Phase 3: every APM route group is now on zod params.

Converts the last 5 route groups (70 route files) to zod params:
- `dependencies` (11 files)
- `mobile` (9 files)
- `services` (19 files, split across two parallel conversion passes)
- `traces` (11 files)
- `transactions` (8 files)

All groups reuse the shared additive zod schemas from `default_api_types.ts` and `@kbn/apm-types`. `dependencyChartQueryRt` (`dependencies/types.ts`) had no consumers outside this group, so it was fully renamed to `dependencyChartQuerySchema`.

**Bug caught by type-check, fixed before merge:** `dependencies/upstream_services.ts` initially ported `environment`/`kuery` as optional (`.partial()`), matching the literal shape of the io-ts `t.partial({ query: ... })` wrapper. But that wrapper was a no-op in the original io-ts: the sibling `t.type({ query: ... })` branch in the same `t.intersection` always requires `query` to be present, so `environment`/`kuery` were actually required at runtime. The plugin's route handler (`server/routes/dependencies/route.ts`) destructures them as required strings, which caught the mismatch as a type error. Fixed to merge `environmentSchema`/`kuerySchema` directly (not `.partial()`), matching original behavior, with a test added for the corrected required-field case.

## Test plan

- [x] Added one `<group>_params.test.ts` per group (plus `services_a`/`services_b` for the split), covering success + failure cases per route.
- [x] Full `kbn-apm-api-shared` jest suite passes: 33 suites, 344/344 tests (after the fix).
- [x] `eslint` clean on all touched files.
- [x] Type-check clean via the oblt CLI for `kbn-apm-api-shared` and the `apm` plugin (0 errors) — this is what caught the `upstream_services.ts` bug above.
- [x] `node scripts/lint_ts_projects.js` clean.
- [ ] No FTR spec coverage added/re-run for these groups in this PR — relying on the unit test coverage above plus manual verification via Kibana Dev Tools Console.