### PR TITLE
[APM] Migrate create/update agent-configuration route params to zod (io-ts -> zod, part 11)

### DIFF
--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/agent_configuration_params.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/agent_configuration_params.test.ts
@@ -6,6 +6,7 @@
  */
 
 import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { createOrUpdateAgentConfigurationRoute } from './create_or_update_configuration';
 import { deleteAgentConfigurationRoute } from './delete_configuration';
 import { agentConfigurationAgentNameRoute } from './get_agent_name';
 import { getSingleAgentConfigurationRoute } from './get_single_configuration';
@@ -92,5 +93,41 @@ describe('searchAgentConfigurationRoute params', () => {
 
   it('rejects a missing service', () => {
     expectParseError(searchAgentConfigurationRoute.params!.safeParse({ body: {} }));
+  });
+});
+
+describe('createOrUpdateAgentConfigurationRoute params', () => {
+  it('accepts a valid body without a query', () => {
+    const result = createOrUpdateAgentConfigurationRoute.params!.safeParse({
+      body: {
+        service: { name: 'opbeans-java', environment: 'production' },
+        settings: { transaction_sample_rate: '0.5' },
+      },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('coerces the optional overwrite query param from a string', () => {
+    const result = createOrUpdateAgentConfigurationRoute.params!.safeParse({
+      query: { overwrite: 'true' },
+      body: { service: {}, settings: {} },
+    });
+
+    expectParseSuccess(result);
+  });
+
+  it('rejects a body with an out-of-range known setting', () => {
+    expectParseError(
+      createOrUpdateAgentConfigurationRoute.params!.safeParse({
+        body: { service: {}, settings: { transaction_sample_rate: '5' } },
+      })
+    );
+  });
+
+  it('rejects a body missing settings', () => {
+    expectParseError(
+      createOrUpdateAgentConfigurationRoute.params!.safeParse({ body: { service: {} } })
+    );
   });
 });

--- a/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/create_or_update_configuration.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-api-shared/src/routes/agent_configuration/create_or_update_configuration.ts
@@ -4,15 +4,15 @@
  * 2.0; you may not use this file except in compliance with the Elastic License
  * 2.0.
  */
-import * as t from 'io-ts';
-import { agentConfigurationIntakeRt } from '@kbn/apm-common';
-import { toBooleanRt } from '@kbn/io-ts-utils';
+import { z } from '@kbn/zod/v4';
+import { BooleanFromString } from '@kbn/zod-helpers/v4';
+import { agentConfigurationIntakeSchema } from '@kbn/apm-common';
 import { defineRoute } from '../types';
 
 export const createOrUpdateAgentConfigurationRoute = defineRoute<void>()({
   endpoint: 'PUT /api/apm/settings/agent-configuration 2023-10-31',
-  params: t.intersection([
-    t.partial({ query: t.partial({ overwrite: toBooleanRt }) }),
-    t.type({ body: agentConfigurationIntakeRt }),
-  ]),
+  params: z.object({
+    query: z.object({ overwrite: BooleanFromString.optional() }).optional(),
+    body: agentConfigurationIntakeSchema,
+  }),
 });

--- a/x-pack/platform/packages/shared/kbn-apm-common/index.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/index.ts
@@ -37,7 +37,9 @@ export {
   serviceRt,
   serviceSchema,
   settingsRt,
+  settingsSchema,
   agentConfigurationIntakeRt,
+  agentConfigurationIntakeSchema,
 } from './src/agent_configuration/runtime_types/agent_configuration_intake_rt';
 export { booleanRt } from './src/agent_configuration/runtime_types/boolean_rt';
 export { captureBodyRt } from './src/agent_configuration/runtime_types/capture_body_rt';

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/agent_configuration_intake_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/agent_configuration_intake_rt.ts
@@ -8,12 +8,21 @@
 import * as t from 'io-ts';
 import { z } from '@kbn/zod/v4';
 import { settingDefinitions } from '../setting_definitions';
-import type { SettingValidation } from '../setting_definitions/types';
+import type { SettingValidation, SettingZodValidation } from '../setting_definitions/types';
 
 // retrieve validation from config definitions settings and validate on the server
 const knownSettings = settingDefinitions.reduce<Record<string, SettingValidation>>(
   (acc, { key, validation }) => {
     acc[key] = validation;
+    return acc;
+  },
+  {}
+);
+
+// zod equivalent of `knownSettings`, additive (io-ts -> zod migration).
+const knownSettingsZod = settingDefinitions.reduce<Record<string, SettingZodValidation>>(
+  (acc, { key, zodValidation }) => {
+    acc[key] = zodValidation;
     return acc;
   },
   {}
@@ -26,9 +35,7 @@ export const serviceRt = t.partial({
 
 /**
  * zod equivalent, additive (see `default_api_types.ts` in `@kbn/apm-api-shared`
- * for why - elastic/kibana#243355). `settingsRt`/`agentConfigurationIntakeRt`
- * are not ported here yet: they pull in the whole per-setting validation
- * subsystem in `../setting_definitions`, which needs its own migration pass.
+ * for why - elastic/kibana#243355).
  */
 export const serviceSchema = z.object({
   name: z.string().optional(),
@@ -44,3 +51,29 @@ export const agentConfigurationIntakeRt = t.intersection([
     settings: settingsRt,
   }),
 ]);
+
+/**
+ * zod equivalent of `settingsRt`: every value must be a string, and known
+ * settings additionally pass their per-setting validation (mirrors io-ts's
+ * `t.intersection([t.record(t.string, t.string), t.partial(knownSettings)])`).
+ */
+export const settingsSchema = z.record(z.string(), z.string()).superRefine((settings, ctx) => {
+  for (const [key, validator] of Object.entries(knownSettingsZod)) {
+    const value = settings[key];
+    if (value !== undefined) {
+      const result = validator.safeParse(value);
+      if (!result.success) {
+        for (const issue of result.error.issues) {
+          ctx.addIssue({ code: 'custom', path: [key], message: issue.message });
+        }
+      }
+    }
+  }
+});
+
+// zod equivalent of `agentConfigurationIntakeRt`, additive.
+export const agentConfigurationIntakeSchema = z.object({
+  agent_name: z.string().optional(),
+  service: serviceSchema,
+  settings: settingsSchema,
+});

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/agent_configuration_intake_schema.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/agent_configuration_intake_schema.test.ts
@@ -1,0 +1,88 @@
+/*
+ * Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+ * or more contributor license agreements. Licensed under the Elastic License
+ * 2.0; you may not use this file except in compliance with the Elastic License
+ * 2.0.
+ */
+
+import { expectParseError, expectParseSuccess } from '@kbn/zod-helpers/v4';
+import { agentConfigurationIntakeSchema } from './agent_configuration_intake_rt';
+
+describe('agentConfigurationIntakeSchema', () => {
+  it('is valid when "transaction_sample_rate" is a string', () => {
+    expectParseSuccess(
+      agentConfigurationIntakeSchema.safeParse({
+        service: { name: 'my-service', environment: 'my-environment' },
+        settings: { transaction_sample_rate: '0.5' },
+      })
+    );
+  });
+
+  it('is invalid when "transaction_sample_rate" is a number', () => {
+    expectParseError(
+      agentConfigurationIntakeSchema.safeParse({
+        service: {},
+        settings: { transaction_sample_rate: 0.5 },
+      })
+    );
+  });
+
+  it('is invalid when "transaction_sample_rate" is out of range (per-setting refinement)', () => {
+    expectParseError(
+      agentConfigurationIntakeSchema.safeParse({
+        service: {},
+        settings: { transaction_sample_rate: '5' },
+      })
+    );
+  });
+
+  it('is invalid when a known enum setting has an unknown value', () => {
+    expectParseError(
+      agentConfigurationIntakeSchema.safeParse({
+        service: {},
+        settings: { capture_body: 'sometimes' },
+      })
+    );
+  });
+
+  it('is valid when a known enum setting has an allowed value', () => {
+    expectParseSuccess(
+      agentConfigurationIntakeSchema.safeParse({
+        service: {},
+        settings: { capture_body: 'all' },
+      })
+    );
+  });
+
+  it('is valid when unknown setting is a string', () => {
+    expectParseSuccess(
+      agentConfigurationIntakeSchema.safeParse({
+        service: { name: 'my-service', environment: 'my-environment' },
+        settings: { my_unknown_setting: '0.5' },
+      })
+    );
+  });
+
+  it('is invalid when unknown setting is a boolean', () => {
+    expectParseError(
+      agentConfigurationIntakeSchema.safeParse({
+        service: { name: 'my-service', environment: 'my-environment' },
+        settings: { my_unknown_setting: false },
+      })
+    );
+  });
+
+  it('accepts an optional agent_name', () => {
+    expectParseSuccess(
+      agentConfigurationIntakeSchema.safeParse({
+        agent_name: 'java',
+        service: { name: 'my-service' },
+        settings: {},
+      })
+    );
+  });
+
+  it('rejects a missing service', () => {
+    expectParseError(agentConfigurationIntakeSchema.safeParse({ settings: {} }));
+  });
+});

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/boolean_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/boolean_rt.ts
@@ -6,5 +6,9 @@
  */
 
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 
 export const booleanRt = t.union([t.literal('true'), t.literal('false')]);
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export const booleanSchema = z.union([z.literal('true'), z.literal('false')]);

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/bytes_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/bytes_rt.ts
@@ -7,6 +7,7 @@
 
 import * as t from 'io-ts';
 import { either } from 'fp-ts/Either';
+import { z } from '@kbn/zod/v4';
 import { amountAndUnitToObject } from '../amount_and_unit';
 import { getRangeTypeMessage } from './get_range_type_message';
 
@@ -49,5 +50,20 @@ export function getBytesRt({ min, max }: { min?: string; max?: string }) {
       });
     },
     t.identity
+  );
+}
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export function getBytesSchema({ min, max }: { min?: string; max?: string }) {
+  const minAsBytes = amountAndUnitToBytes(min) ?? -Infinity;
+  const maxAsBytes = amountAndUnitToBytes(max) ?? Infinity;
+  const message = getRangeTypeMessage(min, max);
+
+  return z.string().refine(
+    (inputAsString) => {
+      const inputAsBytes = amountAndUnitToBytes(inputAsString);
+      return inputAsBytes !== undefined && inputAsBytes >= minAsBytes && inputAsBytes <= maxAsBytes;
+    },
+    { message }
   );
 }

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/capture_body_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/capture_body_rt.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 
 export const captureBodyRt = t.union([
   t.literal('off'),
@@ -13,3 +14,6 @@ export const captureBodyRt = t.union([
   t.literal('transactions'),
   t.literal('all'),
 ]);
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export const captureBodySchema = z.enum(['off', 'errors', 'transactions', 'all']);

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/duration_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/duration_rt.ts
@@ -7,6 +7,7 @@
 
 import * as t from 'io-ts';
 import { either } from 'fp-ts/Either';
+import { z } from '@kbn/zod/v4';
 import type { unitOfTime } from 'moment';
 import moment from 'moment';
 import type { AmountAndUnit } from '../amount_and_unit';
@@ -47,5 +48,24 @@ export function getDurationRt({ min, max }: { min?: string; max?: string }) {
       });
     },
     t.identity
+  );
+}
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export function getDurationSchema({ min, max }: { min?: string; max?: string }) {
+  const minAsMilliseconds = amountAndUnitToMilliseconds(min) ?? -Infinity;
+  const maxAsMilliseconds = amountAndUnitToMilliseconds(max) ?? Infinity;
+  const message = getRangeTypeMessage(min, max);
+
+  return z.string().refine(
+    (inputAsString) => {
+      const inputAsMilliseconds = amountAndUnitToMilliseconds(inputAsString);
+      return (
+        inputAsMilliseconds !== undefined &&
+        inputAsMilliseconds >= minAsMilliseconds &&
+        inputAsMilliseconds <= maxAsMilliseconds
+      );
+    },
+    { message }
   );
 }

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/float_four_decimal_places_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/float_four_decimal_places_rt.ts
@@ -7,6 +7,7 @@
 
 import * as t from 'io-ts';
 import { either } from 'fp-ts/Either';
+import { z } from '@kbn/zod/v4';
 
 export const floatFourDecimalPlacesRt = new t.Type<string, string, unknown>(
   'floatFourDecimalPlacesRt',
@@ -24,4 +25,14 @@ export const floatFourDecimalPlacesRt = new t.Type<string, string, unknown>(
     });
   },
   t.identity
+);
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export const floatFourDecimalPlacesSchema = z.string().refine(
+  (inputAsString) => {
+    const inputAsFloat = parseFloat(inputAsString);
+    const maxFourDecimals = parseFloat(inputAsFloat.toFixed(4)) === inputAsFloat;
+    return inputAsFloat >= 0 && inputAsFloat <= 1 && maxFourDecimals;
+  },
+  { message: 'Must be a number between 0.0000 and 1' }
 );

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/float_three_decimal_places_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/float_three_decimal_places_rt.ts
@@ -7,6 +7,7 @@
 
 import * as t from 'io-ts';
 import { either } from 'fp-ts/Either';
+import { z } from '@kbn/zod/v4';
 
 export const floatThreeDecimalPlacesRt = new t.Type<string, string, unknown>(
   'floatThreeDecimalPlacesRt',
@@ -24,4 +25,14 @@ export const floatThreeDecimalPlacesRt = new t.Type<string, string, unknown>(
     });
   },
   t.identity
+);
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export const floatThreeDecimalPlacesSchema = z.string().refine(
+  (inputAsString) => {
+    const inputAsFloat = parseFloat(inputAsString);
+    const maxThreeDecimals = parseFloat(inputAsFloat.toFixed(3)) === inputAsFloat;
+    return inputAsFloat >= 0 && inputAsFloat <= 1 && maxThreeDecimals;
+  },
+  { message: 'Must be a number between 0.000 and 1' }
 );

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/integer_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/integer_rt.ts
@@ -7,6 +7,7 @@
 
 import * as t from 'io-ts';
 import { either } from 'fp-ts/Either';
+import { z } from '@kbn/zod/v4';
 import { getRangeTypeMessage } from './get_range_type_message';
 
 export function getIntegerRt({
@@ -29,5 +30,24 @@ export function getIntegerRt({
       });
     },
     t.identity
+  );
+}
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export function getIntegerSchema({
+  min = -Infinity,
+  max = Infinity,
+}: {
+  min?: number;
+  max?: number;
+} = {}) {
+  const message = getRangeTypeMessage(min, max);
+
+  return z.string().refine(
+    (inputAsString) => {
+      const inputAsInt = parseInt(inputAsString, 10);
+      return inputAsInt >= min && inputAsInt <= max;
+    },
+    { message }
   );
 }

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/log_ecs_reformatting_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/log_ecs_reformatting_rt.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 
 export const logEcsReformattingRt = t.union([
   t.literal('off'),
@@ -13,3 +14,6 @@ export const logEcsReformattingRt = t.union([
   t.literal('replace'),
   t.literal('override'),
 ]);
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export const logEcsReformattingSchema = z.enum(['off', 'shade', 'replace', 'override']);

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/log_level_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/log_level_rt.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 
 export const logLevelRt = t.union([
   t.literal('trace'),
@@ -15,4 +16,15 @@ export const logLevelRt = t.union([
   t.literal('error'),
   t.literal('critical'),
   t.literal('off'),
+]);
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export const logLevelSchema = z.enum([
+  'trace',
+  'debug',
+  'info',
+  'warning',
+  'error',
+  'critical',
+  'off',
 ]);

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/logging_level_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/logging_level_rt.ts
@@ -6,6 +6,7 @@
  */
 
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 
 export const loggingLevelRt = t.union([
   t.literal('trace'),
@@ -15,4 +16,15 @@ export const loggingLevelRt = t.union([
   t.literal('error'),
   t.literal('fatal'),
   t.literal('off'),
+]);
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export const loggingLevelSchema = z.enum([
+  'trace',
+  'debug',
+  'info',
+  'warn',
+  'error',
+  'fatal',
+  'off',
 ]);

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/storage_size_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/storage_size_rt.ts
@@ -7,6 +7,7 @@
 
 import * as t from 'io-ts';
 import { either } from 'fp-ts/Either';
+import { z } from '@kbn/zod/v4';
 import { amountAndUnitToObject } from '../amount_and_unit';
 import { getRangeTypeMessage } from './get_range_type_message';
 
@@ -62,5 +63,20 @@ export function getStorageSizeRt({ min, max }: { min?: string; max?: string }) {
       });
     },
     t.identity
+  );
+}
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export function getStorageSizeSchema({ min, max }: { min?: string; max?: string }) {
+  const minAsBytes = amountAndUnitToBytes({ value: min, decimalUnitBase: true }) ?? -Infinity;
+  const maxAsBytes = amountAndUnitToBytes({ value: max, decimalUnitBase: true }) ?? Infinity;
+  const message = getRangeTypeMessage(min, max);
+
+  return z.string().refine(
+    (inputAsString) => {
+      const inputAsBytes = amountAndUnitToBytes({ value: inputAsString, decimalUnitBase: true });
+      return inputAsBytes !== undefined && inputAsBytes >= minAsBytes && inputAsBytes <= maxAsBytes;
+    },
+    { message }
   );
 }

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/trace_continuation_strategy_rt.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/runtime_types/trace_continuation_strategy_rt.ts
@@ -6,9 +6,13 @@
  */
 
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 
 export const traceContinuationStrategyRt = t.union([
   t.literal('continue'),
   t.literal('restart'),
   t.literal('restart_external'),
 ]);
+
+// zod equivalent, additive (io-ts -> zod migration, elastic/kibana#243355).
+export const traceContinuationStrategySchema = z.enum(['continue', 'restart', 'restart_external']);

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/edot_sdk_settings.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/edot_sdk_settings.ts
@@ -7,7 +7,7 @@
 
 import { i18n } from '@kbn/i18n';
 import type { RawSettingDefinition } from './types';
-import { loggingLevelRt } from '../runtime_types/logging_level_rt';
+import { loggingLevelRt, loggingLevelSchema } from '../runtime_types/logging_level_rt';
 
 export const edotSDKSettings: RawSettingDefinition[] = [
   {
@@ -79,6 +79,7 @@ export const edotSDKSettings: RawSettingDefinition[] = [
   {
     key: 'logging_level',
     validation: loggingLevelRt,
+    zodValidation: loggingLevelSchema,
     type: 'select',
     defaultValue: 'info',
     label: i18n.translate('apmCommon.agentConfig.loggingLevel.label', {

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/general_settings.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/general_settings.ts
@@ -7,10 +7,16 @@
 
 import { i18n } from '@kbn/i18n';
 import { EDOT_AGENT_NAMES, OTEL_AGENT_NAMES } from '@kbn/elastic-agent-utils/src/agent_names';
-import { captureBodyRt } from '../runtime_types/capture_body_rt';
-import { logLevelRt } from '../runtime_types/log_level_rt';
-import { logEcsReformattingRt } from '../runtime_types/log_ecs_reformatting_rt';
-import { traceContinuationStrategyRt } from '../runtime_types/trace_continuation_strategy_rt';
+import { captureBodyRt, captureBodySchema } from '../runtime_types/capture_body_rt';
+import { logLevelRt, logLevelSchema } from '../runtime_types/log_level_rt';
+import {
+  logEcsReformattingRt,
+  logEcsReformattingSchema,
+} from '../runtime_types/log_ecs_reformatting_rt';
+import {
+  traceContinuationStrategyRt,
+  traceContinuationStrategySchema,
+} from '../runtime_types/trace_continuation_strategy_rt';
 import type { RawSettingDefinition } from './types';
 
 export const generalSettings: RawSettingDefinition[] = [
@@ -70,6 +76,7 @@ export const generalSettings: RawSettingDefinition[] = [
   {
     key: 'capture_body',
     validation: captureBodyRt,
+    zodValidation: captureBodySchema,
     type: 'select',
     defaultValue: 'off',
     label: i18n.translate('apmCommon.agentConfig.captureBody.label', {
@@ -229,6 +236,7 @@ export const generalSettings: RawSettingDefinition[] = [
   {
     key: 'log_ecs_reformatting',
     validation: logEcsReformattingRt,
+    zodValidation: logEcsReformattingSchema,
     type: 'select',
     defaultValue: 'off',
     label: i18n.translate('apmCommon.agentConfig.logEcsReformatting.label', {
@@ -253,6 +261,7 @@ export const generalSettings: RawSettingDefinition[] = [
   {
     key: 'log_level',
     validation: logLevelRt,
+    zodValidation: logLevelSchema,
     type: 'select',
     defaultValue: 'info',
     label: i18n.translate('apmCommon.agentConfig.logLevel.label', {
@@ -451,6 +460,7 @@ export const generalSettings: RawSettingDefinition[] = [
   {
     key: 'trace_continuation_strategy',
     validation: traceContinuationStrategyRt,
+    zodValidation: traceContinuationStrategySchema,
     type: 'select',
     defaultValue: 'continue',
     label: i18n.translate('apmCommon.agentConfig.traceContinuationStrategy.label', {

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/index.test.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/index.test.ts
@@ -287,6 +287,7 @@ describe('settingDefinitions', () => {
             'includeAgents',
             'label',
             'validation',
+            'zodValidation',
           ]),
           validationName: def.validation.name,
         };

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/index.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/index.ts
@@ -6,40 +6,48 @@
  */
 
 import * as t from 'io-ts';
+import { z } from '@kbn/zod/v4';
 import { sortBy } from 'lodash';
 import { isRight } from 'fp-ts/Either';
 import { PathReporter } from 'io-ts/lib/PathReporter';
 import type { AgentName } from '@kbn/elastic-agent-utils';
 import { isEDOTAgentName, isOTELAgentName, isRumOrMobileAgentName } from '@kbn/elastic-agent-utils';
-import { booleanRt } from '../runtime_types/boolean_rt';
-import { getIntegerRt } from '../runtime_types/integer_rt';
-import { floatThreeDecimalPlacesRt } from '../runtime_types/float_three_decimal_places_rt';
-import { floatFourDecimalPlacesRt } from '../runtime_types/float_four_decimal_places_rt';
+import { booleanRt, booleanSchema } from '../runtime_types/boolean_rt';
+import { getIntegerRt, getIntegerSchema } from '../runtime_types/integer_rt';
+import {
+  floatThreeDecimalPlacesRt,
+  floatThreeDecimalPlacesSchema,
+} from '../runtime_types/float_three_decimal_places_rt';
+import {
+  floatFourDecimalPlacesRt,
+  floatFourDecimalPlacesSchema,
+} from '../runtime_types/float_four_decimal_places_rt';
 import type { RawSettingDefinition, SettingDefinition } from './types';
 import { generalSettings } from './general_settings';
 import { javaSettings } from './java_settings';
 import { edotSDKSettings } from './edot_sdk_settings';
 import { mobileSettings } from './mobile_settings';
-import { getDurationRt } from '../runtime_types/duration_rt';
-import { getBytesRt } from '../runtime_types/bytes_rt';
-import { getStorageSizeRt } from '../runtime_types/storage_size_rt';
+import { getDurationRt, getDurationSchema } from '../runtime_types/duration_rt';
+import { getBytesRt, getBytesSchema } from '../runtime_types/bytes_rt';
+import { getStorageSizeRt, getStorageSizeSchema } from '../runtime_types/storage_size_rt';
 
 function getSettingDefaults(setting: RawSettingDefinition): SettingDefinition {
   switch (setting.type) {
     case 'select':
-      return { validation: t.string, ...setting };
+      return { validation: t.string, zodValidation: z.string(), ...setting };
 
     case 'boolean':
-      return { validation: booleanRt, ...setting };
+      return { validation: booleanRt, zodValidation: booleanSchema, ...setting };
 
     case 'text':
-      return { validation: t.string, ...setting };
+      return { validation: t.string, zodValidation: z.string(), ...setting };
 
     case 'integer': {
       const { min, max } = setting;
 
       return {
         validation: getIntegerRt({ min, max }),
+        zodValidation: getIntegerSchema({ min, max }),
         min,
         max,
         ...setting,
@@ -50,11 +58,13 @@ function getSettingDefaults(setting: RawSettingDefinition): SettingDefinition {
       if (setting.key === 'transaction_sample_rate' || setting.key === 'sampling_rate') {
         return {
           validation: floatFourDecimalPlacesRt,
+          zodValidation: floatFourDecimalPlacesSchema,
           ...setting,
         };
       }
       return {
         validation: floatThreeDecimalPlacesRt,
+        zodValidation: floatThreeDecimalPlacesSchema,
         ...setting,
       };
     }
@@ -66,6 +76,7 @@ function getSettingDefaults(setting: RawSettingDefinition): SettingDefinition {
 
       return {
         validation: getBytesRt({ min, max }),
+        zodValidation: getBytesSchema({ min, max }),
         units,
         min,
         ...setting,
@@ -79,6 +90,7 @@ function getSettingDefaults(setting: RawSettingDefinition): SettingDefinition {
 
       return {
         validation: getStorageSizeRt({ min, max }),
+        zodValidation: getStorageSizeSchema({ min, max }),
         units,
         min,
         ...setting,
@@ -92,6 +104,7 @@ function getSettingDefaults(setting: RawSettingDefinition): SettingDefinition {
 
       return {
         validation: getDurationRt({ min, max }),
+        zodValidation: getDurationSchema({ min, max }),
         units,
         min,
         ...setting,

--- a/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/types.ts
+++ b/x-pack/platform/packages/shared/kbn-apm-common/src/agent_configuration/setting_definitions/types.ts
@@ -6,10 +6,20 @@
  */
 
 import type * as t from 'io-ts';
+import type { z } from '@kbn/zod/v4';
 import type { AgentName } from '@kbn/elastic-agent-utils';
 
 // TODO: is it possible to get rid of `any`?
 export type SettingValidation = t.Type<any, string, unknown>;
+
+/**
+ * zod equivalent of `SettingValidation`, additive (io-ts -> zod migration,
+ * elastic/kibana#243355). Used to build the zod agent-config intake schema
+ * without disturbing the io-ts `validation` field the UI form still relies on.
+ * `ZodTypeAny` (not `ZodType<string>`) so enum-output schemas assign cleanly;
+ * every validator here still only accepts and returns strings.
+ */
+export type SettingZodValidation = z.ZodTypeAny;
 
 interface BaseSetting {
   /**
@@ -57,12 +67,14 @@ interface BaseSetting {
 interface TextSetting extends BaseSetting {
   type: 'text';
   validation?: SettingValidation;
+  zodValidation?: SettingZodValidation;
 }
 
 interface SelectSetting extends BaseSetting {
   type: 'select';
   options: Array<{ text: string; value: string }>;
   validation?: SettingValidation;
+  zodValidation?: SettingZodValidation;
 }
 
 interface BooleanSetting extends BaseSetting {
@@ -115,4 +127,9 @@ export type SettingDefinition = RawSettingDefinition & {
    * runtime validation of input
    */
   validation: SettingValidation;
+
+  /**
+   * zod equivalent of `validation`, additive (io-ts -> zod migration).
+   */
+  zodValidation: SettingZodValidation;
 };


### PR DESCRIPTION
## Summary

Part of the `io-ts` -> `@kbn/zod` migration tracked in elastic/kibana#243355.

Migrates the last remaining io-ts route param in the `agent_configuration` group: `PUT /api/apm/settings/agent-configuration` (create/update). Its body is `agentConfigurationIntakeRt` -> `settingsRt`, which pulls in the whole per-setting validation subsystem in `@kbn/apm-common` — hence it was deferred until now.

Done **faithfully and additively**: server-side per-setting validation (ranges, formats, enums) is fully preserved, not relaxed.

## Changes

- Added zod siblings of every per-setting validator alongside the untouched io-ts ones: `booleanSchema`, `getIntegerSchema`, `floatThreeDecimalPlacesSchema`, `floatFourDecimalPlacesSchema`, `getDurationSchema`, `getBytesSchema`, `getStorageSizeSchema`, `captureBodySchema`, `logLevelSchema`, `loggingLevelSchema`, `logEcsReformattingSchema`, `traceContinuationStrategySchema`. Each is a `z.string()` refinement / string-enum, matching the io-ts `t.Type<string, string, unknown>` shape and error messages.
- Threaded a `zodValidation` field through the setting definitions (`SettingDefinition` type + `getSettingDefaults` + the 5 raw settings with explicit validators), next to the existing io-ts `validation` field.
- Built `settingsSchema` (zod) reproducing `t.intersection([t.record(t.string, t.string), t.partial(knownSettings)])` via a `z.record(...).superRefine(...)`: every value must be a string, and known keys additionally pass their per-setting refinement.
- Built `agentConfigurationIntakeSchema` (zod) and switched the route to it (`toBooleanRt` -> `BooleanFromString` for the `overwrite` query param).

The io-ts validators, `validateSetting()`, and the Fleet policy form are **untouched** — they keep using the io-ts `validation` field until Phase 4/5. `AgentConfigurationIntake` stays io-ts-derived; the zod-inferred body is assignable to it, so the route handler needs no changes (verified by type-check).

## Test plan

- [x] New `agent_configuration_intake_schema.test.ts` in `@kbn/apm-common` — mirrors the io-ts intake tests plus per-setting-refinement and enum cases.
- [x] Extended `agent_configuration_params.test.ts` in `@kbn/apm-api-shared` with the create/update route (valid body, `overwrite` coercion, out-of-range rejection, missing settings).
- [x] `@kbn/apm-common` agent_configuration suite: 236/236 (existing index.test.ts snapshot preserved by omitting `zodValidation`, consistent with how `validation` is omitted).
- [x] Full `@kbn/apm-api-shared` suite: 33 suites, 325/325.
- [x] Type-check clean via oblt CLI for `kbn-apm-common`, `kbn-apm-api-shared`, and the `apm` plugin (0 errors).
- [x] `node scripts/lint_ts_projects.js` clean; eslint clean.
- [ ] No FTR re-run in this PR — the existing `agent_configuration.spec.ts` FTR spec covers this endpoint; relying on that plus the unit coverage above and manual Dev Tools verification.